### PR TITLE
"FetchCoinAssetsBuildStep" gets "fetch_at_build_enabled" parameter

### DIFF
--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -67,6 +67,7 @@
         }
     },
     "coins": {
+        "fetch_at_build_enabled": true,
         "update_commit_on_build": true,
         "bundled_coins_repo_commit": "7d2ca04e250b59362641da69f752aec8cbd83838",
         "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",

--- a/packages/komodo_wallet_build_transformer/lib/src/steps/fetch_coin_assets_build_step.dart
+++ b/packages/komodo_wallet_build_transformer/lib/src/steps/fetch_coin_assets_build_step.dart
@@ -22,6 +22,7 @@ class FetchCoinAssetsBuildStep extends BuildStep {
     required this.buildConfigOutput,
     required this.githubApiProvider,
     this.receivePort,
+    this.enabled = true,
   }) {
     receivePort?.listen(
       (dynamic message) => onProgressData(message, receivePort),
@@ -64,6 +65,7 @@ class FetchCoinAssetsBuildStep extends BuildStep {
       buildConfigOutput: outputBuildConfigFile,
       githubApiProvider: provider,
       receivePort: receivePort,
+      enabled: config.fetchAtBuildEnabled,
     );
   }
 
@@ -79,6 +81,7 @@ class FetchCoinAssetsBuildStep extends BuildStep {
   @override
   final String id = idStatic;
   static const idStatic = 'fetch_coin_assets';
+  final bool enabled;
 
   @override
   Future<void> build() async {
@@ -136,6 +139,10 @@ class FetchCoinAssetsBuildStep extends BuildStep {
 
   @override
   Future<bool> canSkip() async {
+    if (!enabled) {
+      return true;
+    }
+
     final latestCommitHash = await githubApiProvider.getLatestCommitHash(
       branch: config.coinsRepoBranch,
     );

--- a/packages/komodo_wallet_build_transformer/lib/src/steps/models/coin_assets/coin_build_config.dart
+++ b/packages/komodo_wallet_build_transformer/lib/src/steps/models/coin_assets/coin_build_config.dart
@@ -12,6 +12,7 @@ import 'package:path/path.dart' as path;
 class CoinBuildConfig {
   /// Creates a new instance of [CoinBuildConfig].
   CoinBuildConfig({
+    required this.fetchAtBuildEnabled,
     required this.bundledCoinsRepoCommit,
     required this.updateCommitOnBuild,
     required this.coinsRepoApiUrl,
@@ -25,6 +26,7 @@ class CoinBuildConfig {
   /// Creates a new instance of [CoinBuildConfig] from a JSON object.
   factory CoinBuildConfig.fromJson(Map<String, dynamic> json) {
     return CoinBuildConfig(
+      fetchAtBuildEnabled: json['fetch_at_build_enabled'] as bool,
       updateCommitOnBuild: json['update_commit_on_build'] as bool,
       bundledCoinsRepoCommit: json['bundled_coins_repo_commit'] as String,
       coinsRepoApiUrl: json['coins_repo_api_url'] as String,
@@ -39,6 +41,9 @@ class CoinBuildConfig {
       ),
     );
   }
+
+  /// Indicates whether fetching updates of the coins assets are enabled.
+  final bool fetchAtBuildEnabled;
 
   /// The commit hash or branch coins repository to use when fetching coin
   /// assets.
@@ -77,6 +82,7 @@ class CoinBuildConfig {
 
   CoinBuildConfig copyWith({
     String? bundledCoinsRepoCommit,
+    bool? fetchAtBuildEnabled,
     bool? updateCommitOnBuild,
     String? coinsRepoApiUrl,
     String? coinsRepoContentUrl,
@@ -86,6 +92,7 @@ class CoinBuildConfig {
     Map<String, String>? mappedFolders,
   }) {
     return CoinBuildConfig(
+      fetchAtBuildEnabled: fetchAtBuildEnabled ?? this.fetchAtBuildEnabled,
       updateCommitOnBuild: updateCommitOnBuild ?? this.updateCommitOnBuild,
       bundledCoinsRepoCommit:
           bundledCoinsRepoCommit ?? this.bundledCoinsRepoCommit,
@@ -101,6 +108,7 @@ class CoinBuildConfig {
 
   /// Converts the [CoinBuildConfig] instance to a JSON object.
   Map<String, dynamic> toJson() => <String, dynamic>{
+        'fetch_at_build_enabled': fetchAtBuildEnabled,
         'update_commit_on_build': updateCommitOnBuild,
         'bundled_coins_repo_commit': bundledCoinsRepoCommit,
         'coins_repo_api_url': coinsRepoApiUrl,


### PR DESCRIPTION
Transfers the changes from [#164](https://github.com/KomodoPlatform/komodo-wallet/pull/164)

In `build_config.json`, we can set:

```
"coins": {
        "fetch_at_build_enabled": false,
```

That makes `canSkip` of the `FetchCoinAssetsBuildStep` returns `true`; skipping the coin configs fetching, allowing users to manually edit them. 