### PR TITLE
fix(build-transformer): ios xcode errors

### DIFF
--- a/packages/komodo_wallet_build_transformer/lib/src/steps/fetch_defi_api_build_step.dart
+++ b/packages/komodo_wallet_build_transformer/lib/src/steps/fetch_defi_api_build_step.dart
@@ -613,10 +613,10 @@ class FetchDefiApiStep extends BuildStep {
 
   String findNodeWindows() {
     final commonLocations = [
-      'C:/Program Files/nodejs/npm',
       'C:/Program Files/nodejs/npm.cmd',
-      'C:/Program Files (x86)/nodejs/npm',
       'C:/Program Files (x86)/nodejs/npm.cmd',
+      'C:/Program Files/nodejs/npm',
+      'C:/Program Files (x86)/nodejs/npm',
     ];
 
     for (final location in commonLocations) {


### PR DESCRIPTION
Fixes the "npm not found" build step error when building for iOS through Xcode, and adds multiple lookup options for the npm path on Windows and Unix-based platforms. 