### PR TITLE
fix(komodo-defi-framework): normalise kdf startup process between native and wasm

### DIFF
--- a/packages/komodo_defi_framework/lib/src/operations/kdf_operations_local_executable.dart
+++ b/packages/komodo_defi_framework/lib/src/operations/kdf_operations_local_executable.dart
@@ -135,11 +135,10 @@ class KdfOperationsLocalExecutable implements IKdfOperations {
       return KdfStartupResult.alreadyRunning;
     }
 
-    // TODO: Log level
-
     _logCallback('Starting KDF with parameters (Coins Removed): ${{
       ...params,
       'coins': <JsonMap>[],
+      'log_level': logLevel ?? 3,
     }.censored().toJsonString()}');
 
     _process = await _startKdf([params.toJsonString()]);

--- a/playground/lib/kdf_operations/kdf_operations_server.dart
+++ b/playground/lib/kdf_operations/kdf_operations_server.dart
@@ -1,0 +1,3 @@
+export './kdf_operations_server_stub.dart' 
+  if (dart.library.html) './kdf_operations_server_web.dart'
+  if (dart.library.io) './kdf_operations_server_native.dart';

--- a/playground/lib/kdf_operations/kdf_operations_server_native.dart
+++ b/playground/lib/kdf_operations/kdf_operations_server_native.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:komodo_defi_framework/komodo_defi_framework.dart';
+// ignore: depend_on_referenced_packages
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+class KdfHttpServerOperations implements IKdfOperations {
+  KdfHttpServerOperations(
+    LocalConfig _, {
+    void Function(String)? logCallback,
+  });
+
+  @override
+  String get operationsName => 'Unsupported HTTP Server Operations';
+
+  @override
+  Future<KdfStartupResult> kdfMain(JsonMap startParams, {int? logLevel}) async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+
+  @override
+  Future<MainStatus> kdfMainStatus() async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+
+  @override
+  Future<StopStatus> kdfStop() async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+
+  @override
+  Future<bool> isRunning() async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+
+  @override
+  Future<String?> version() async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+
+  @override
+  Future<Map<String, dynamic>> mm2Rpc(Map<String, dynamic> request) async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+
+  @override
+  Future<void> validateSetup() async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+
+  @override
+  Future<bool> isAvailable(IKdfHostConfig hostConfig) async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+}

--- a/playground/lib/kdf_operations/kdf_operations_server_stub.dart
+++ b/playground/lib/kdf_operations/kdf_operations_server_stub.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:komodo_defi_framework/komodo_defi_framework.dart';
+// ignore: depend_on_referenced_packages
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+class KdfHttpServerOperations implements IKdfOperations {
+  KdfHttpServerOperations(
+    LocalConfig _, {
+    void Function(String)? logCallback,
+  });
+
+  @override
+  String get operationsName => 'Unsupported HTTP Server Operations';
+
+  @override
+  Future<KdfStartupResult> kdfMain(JsonMap startParams, {int? logLevel}) async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+
+  @override
+  Future<MainStatus> kdfMainStatus() async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+
+  @override
+  Future<StopStatus> kdfStop() async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+
+  @override
+  Future<bool> isRunning() async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+
+  @override
+  Future<String?> version() async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+
+  @override
+  Future<Map<String, dynamic>> mm2Rpc(Map<String, dynamic> request) async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+
+  @override
+  Future<void> validateSetup() async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+
+  @override
+  Future<bool> isAvailable(IKdfHostConfig hostConfig) async {
+    throw UnsupportedError('Unknown platforms are not supported');
+  }
+}

--- a/playground/lib/kdf_operations/kdf_operations_server_web.dart
+++ b/playground/lib/kdf_operations/kdf_operations_server_web.dart
@@ -1,28 +1,30 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:js_interop' as js_interop;
+// this warning is pointless, since `web` and `js_interop` fail to compile on
+// native platforms, so they aren't safe to import without conditional
+// imports either (yet)
+// ignore: avoid_web_libraries_in_flutter
 import 'dart:js_util' as js_util;
+
 import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
-import 'package:shelf/shelf.dart';
+import 'package:komodo_defi_framework/komodo_defi_framework.dart';
+// ignore: depend_on_referenced_packages
+import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:shelf_proxy/shelf_proxy.dart';
-import 'package:komodo_defi_framework/komodo_defi_framework.dart';
-import 'package:komodo_defi_types/komodo_defi_types.dart';
 
-class KdfWasmHttpServerOperations implements IKdfOperations {
-  final LocalConfig _config;
+class KdfHttpServerOperations implements IKdfOperations {
   late HeadlessInAppWebView _webView;
   late HttpServer _server;
   bool _isInitialized = false;
-  js_interop.JSObject? _kdfModule;
-  bool _libraryLoaded = false;
-  void Function(String)? _logger;
+  final void Function(String)? _logger;
 
-  KdfWasmHttpServerOperations(this._config,
-      {void Function(String)? logCallback})
-      : _logger = logCallback;
+  KdfHttpServerOperations(
+    LocalConfig config, {
+    void Function(String)? logCallback,
+  }) : _logger = logCallback;
 
   @override
   String get operationsName => 'WASM HTTP Server Operations';

--- a/playground/lib/main.dart
+++ b/playground/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:json_editor_flutter/json_editor_flutter.dart';
 import 'package:komodo_defi_framework/komodo_defi_framework.dart';
-import 'package:komodo_defi_framework_example/kdf_operations_wasm_server.dart';
+import 'package:komodo_defi_framework_example/kdf_operations/kdf_operations_server.dart';
 import 'package:komodo_defi_framework_example/widgets/request_playground.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher_string.dart';
@@ -623,7 +623,7 @@ class _MyAppState extends State<MyApp> {
       _kdfFramework = exposeHttp && !kIsWeb
           ? KomodoDefiFramework.createWithOperations(
               hostConfig: config,
-              kdfOperations: KdfWasmHttpServerOperations(config as LocalConfig),
+              kdfOperations: KdfHttpServerOperations(config as LocalConfig),
               externalLogger: _logController.add,
             )
           : KomodoDefiFramework.create(

--- a/playground/macos/Podfile.lock
+++ b/playground/macos/Podfile.lock
@@ -1,7 +1,11 @@
 PODS:
+  - flutter_inappwebview_macos (0.0.1):
+    - FlutterMacOS
+    - OrderedSet (~> 6.0.3)
   - FlutterMacOS (1.0.0)
   - komodo_defi_framework (0.0.1):
     - FlutterMacOS
+  - OrderedSet (6.0.3)
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -12,13 +16,20 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
+  - flutter_inappwebview_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_inappwebview_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - komodo_defi_framework (from `Flutter/ephemeral/.symlinks/plugins/komodo_defi_framework/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
 
+SPEC REPOS:
+  trunk:
+    - OrderedSet
+
 EXTERNAL SOURCES:
+  flutter_inappwebview_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_inappwebview_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   komodo_defi_framework:
@@ -31,8 +42,10 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
+  flutter_inappwebview_macos: bdf207b8f4ebd58e86ae06cd96b147de99a67c9b
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   komodo_defi_framework: f716eeef2f8d5cd3a97efe7bb103e8e18285032c
+  OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   url_launcher_macos: 5f437abeda8c85500ceb03f5c1938a8c5a705399

--- a/playground/macos/Runner/Info.plist
+++ b/playground/macos/Runner/Info.plist
@@ -1,41 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(FLUTTER_BUILD_NAME)</string>
+	<key>CFBundleVersion</key>
+	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSAllowsArbitraryLoadsInWebContent</key>
+	<true/>
+	<key>NSAllowsLocalNetworking</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>CFBundleDevelopmentRegion</key>
-		<string>$(DEVELOPMENT_LANGUAGE)</string>
-		<key>CFBundleExecutable</key>
-		<string>$(EXECUTABLE_NAME)</string>
-		<key>CFBundleIconFile</key>
-		<string></string>
-		<key>CFBundleIdentifier</key>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-		<key>CFBundleInfoDictionaryVersion</key>
-		<string>6.0</string>
-		<key>CFBundleName</key>
-		<string>$(PRODUCT_NAME)</string>
-		<key>CFBundlePackageType</key>
-		<string>APPL</string>
-		<key>CFBundleShortVersionString</key>
-		<string>$(FLUTTER_BUILD_NAME)</string>
-		<key>CFBundleVersion</key>
-		<string>$(FLUTTER_BUILD_NUMBER)</string>
-		<key>LSMinimumSystemVersion</key>
-		<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-		<key>NSHumanReadableCopyright</key>
-		<string>$(PRODUCT_COPYRIGHT)</string>
-		<key>NSMainNibFile</key>
-		<string>MainMenu</string>
-		<key>NSPrincipalClass</key>
-		<string>NSApplication</string>
-		<key>NSAppTransportSecurity</key>
-		<dict>
-			<key>NSAllowsArbitraryLoads</key>
-			<true/>
-		</dict>
-		<key>NSAllowsArbitraryLoadsInWebContent</key>
-		<true/>
-		<key>NSAllowsLocalNetworking</key>
+		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSHumanReadableCopyright</key>
+	<string>$(PRODUCT_COPYRIGHT)</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
 </plist>


### PR DESCRIPTION
Implement status polling similar to the approach used for `KdfOperationsLocalExecutable`. 
- Wait duration was reduced from 30 seconds to 15, since the WASM implementation does not have a process to watch for exit status codes.

One alternative could be to add a callback function to KDF for startup success/failure, similar to the log function callback. This would provide instant feedback in case of failure, similar to the process exit code watching done on native platforms.