### PR TITLE
feature(build-transformer): concurrent coin asset download

### DIFF
--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -27,11 +27,12 @@
     "coins": {
         "fetch_at_build_enabled": true,
         "update_commit_on_build": true,
+        "concurrent_downloads_enabled": true,
+        "runtime_updates_enabled": true,
         "bundled_coins_repo_commit": "875ae0d35552119d38e749b84a99c5ad9e71bee7",
         "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",
         "coins_repo_content_url": "https://komodoplatform.github.io/coins",
         "coins_repo_branch": "master",
-        "runtime_updates_enabled": true,
         "mapped_files": {
             "assets/config/coins_config.json": "utils/coins_config_unfiltered.json",
             "assets/config/coins.json": "coins"

--- a/packages/komodo_wallet_build_transformer/bin/komodo_wallet_build_transformer.dart
+++ b/packages/komodo_wallet_build_transformer/bin/komodo_wallet_build_transformer.dart
@@ -138,6 +138,12 @@ void main(List<String> arguments) async {
     }
 
     final githubToken = Platform.environment[githubTokenEnvName];
+    if (githubToken == null) {
+      log.warning(
+        'GitHub token not set. Some build steps may fail. '
+        'Set the $githubTokenEnvName environment variable to fix this.',
+      );
+    }
 
     final canRunConcurrent = _argResults.flag('concurrent');
 

--- a/packages/komodo_wallet_build_transformer/lib/src/steps/fetch_coin_assets_build_step.dart
+++ b/packages/komodo_wallet_build_transformer/lib/src/steps/fetch_coin_assets_build_step.dart
@@ -108,7 +108,10 @@ class FetchCoinAssetsBuildStep extends BuildStep {
       );
     }
 
-    await downloader.download(
+    final downloadMethod = config.concurrentDownloadsEnabled
+        ? downloader.download
+        : downloader.downloadSync;
+    await downloadMethod(
       configWithUpdatedCommit.bundledCoinsRepoCommit,
       _adjustPaths(configWithUpdatedCommit.mappedFiles),
       _adjustPaths(configWithUpdatedCommit.mappedFolders),

--- a/packages/komodo_wallet_build_transformer/lib/src/steps/github/github_api_provider.dart
+++ b/packages/komodo_wallet_build_transformer/lib/src/steps/github/github_api_provider.dart
@@ -43,12 +43,15 @@ class GithubApiProvider {
       _headers['Authorization'] = 'Bearer $token';
     }
   }
+
   final String _baseUrl;
   final String _branch;
   final Map<String, String> _headers = {
     'Accept': 'application/vnd.github.v3+json',
   };
   final _log = Logger('GithubApiProvider');
+
+  bool get hasToken => _headers.containsKey('Authorization');
 
   /// Retrieves the contents of a file from the repository API. The [filePath]
   /// parameter specifies the path of the file within the repository.

--- a/packages/komodo_wallet_build_transformer/lib/src/steps/models/coin_assets/coin_build_config.dart
+++ b/packages/komodo_wallet_build_transformer/lib/src/steps/models/coin_assets/coin_build_config.dart
@@ -21,18 +21,21 @@ class CoinBuildConfig {
     required this.runtimeUpdatesEnabled,
     required this.mappedFiles,
     required this.mappedFolders,
+    required this.concurrentDownloadsEnabled,
   });
 
   /// Creates a new instance of [CoinBuildConfig] from a JSON object.
   factory CoinBuildConfig.fromJson(Map<String, dynamic> json) {
     return CoinBuildConfig(
-      fetchAtBuildEnabled: json['fetch_at_build_enabled'] as bool,
-      updateCommitOnBuild: json['update_commit_on_build'] as bool,
+      fetchAtBuildEnabled: json['fetch_at_build_enabled'] as bool? ?? true,
+      updateCommitOnBuild: json['update_commit_on_build'] as bool? ?? true,
       bundledCoinsRepoCommit: json['bundled_coins_repo_commit'] as String,
       coinsRepoApiUrl: json['coins_repo_api_url'] as String,
       coinsRepoContentUrl: json['coins_repo_content_url'] as String,
       coinsRepoBranch: json['coins_repo_branch'] as String,
-      runtimeUpdatesEnabled: json['runtime_updates_enabled'] as bool,
+      runtimeUpdatesEnabled: json['runtime_updates_enabled'] as bool? ?? true,
+      concurrentDownloadsEnabled:
+          json['concurrent_downloads_enabled'] as bool? ?? true,
       mappedFiles: Map<String, String>.from(
         json['mapped_files'] as Map<String, dynamic>? ?? {},
       ),
@@ -54,6 +57,11 @@ class CoinBuildConfig {
   /// If `false`, the commit hash will not be updated and the configured commit
   /// hash will be used.
   final bool updateCommitOnBuild;
+
+  /// Indicates whether concurrent downloads of coin assets are enabled.
+  /// If `true`, multiple coin assets will be downloaded concurrently.
+  /// If `false`, coin assets will be downloaded sequentially.
+  final bool concurrentDownloadsEnabled;
 
   /// The GitHub API of the coins repository used to fetch directory contents
   /// with SHA hashes from the GitHub API.
@@ -88,6 +96,7 @@ class CoinBuildConfig {
     String? coinsRepoContentUrl,
     String? coinsRepoBranch,
     bool? runtimeUpdatesEnabled,
+    bool? concurrentDownloadsEnabled,
     Map<String, String>? mappedFiles,
     Map<String, String>? mappedFolders,
   }) {
@@ -101,6 +110,8 @@ class CoinBuildConfig {
       coinsRepoBranch: coinsRepoBranch ?? this.coinsRepoBranch,
       runtimeUpdatesEnabled:
           runtimeUpdatesEnabled ?? this.runtimeUpdatesEnabled,
+      concurrentDownloadsEnabled:
+          concurrentDownloadsEnabled ?? this.concurrentDownloadsEnabled,
       mappedFiles: mappedFiles ?? this.mappedFiles,
       mappedFolders: mappedFolders ?? this.mappedFolders,
     );
@@ -117,6 +128,7 @@ class CoinBuildConfig {
         'runtime_updates_enabled': runtimeUpdatesEnabled,
         'mapped_files': mappedFiles,
         'mapped_folders': mappedFolders,
+        'concurrent_downloads_enabled': concurrentDownloadsEnabled,
       };
 
   /// Loads the coins runtime update configuration synchronously from the


### PR DESCRIPTION
## Changes

- Add and default to concurrent coin asset downloads to improve clean build times (e.g. CI/CD, fresh clones, occasionally when switching branches or updating package versions).
- Add a `concurrent_downloads_enabled` flag to `build_config.json` to allow for changing the configuration if the need arises.
- Add a warning if the GitHub token is not present in the build environment to clarify issues around the GitHub API rate limits that can cause the build to fail (whether concurrent downloads are enabled or not).
