### PR TITLE
fix(kdf_operations): reduce wasm log verbosity in release mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ migrate_working_dir/
 .pub/
 /build/
 contrib/coins_config.json
+**/.plugin_symlinks/*
 
 # Web related
 web/dist/*.js

--- a/packages/komodo_defi_framework/lib/src/operations/kdf_operations_native.dart
+++ b/packages/komodo_defi_framework/lib/src/operations/kdf_operations_native.dart
@@ -139,8 +139,8 @@ class KdfOperationsNativeLibrary implements IKdfOperations {
 
   @override
   Future<Map<String, dynamic>> mm2Rpc(Map<String, dynamic> request) async {
-    _log('mm2 config: ${_config.toJson()}');
-    _log('mm2Rpc request (pre-process): $request');
+    if (kDebugMode) _log('mm2 config: ${_config.toJson()}');
+    if (kDebugMode) _log('mm2Rpc request (pre-process): $request');
     request['userpass'] = _config.rpcPassword;
     final response = await _client.post(
       _url,

--- a/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
+++ b/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
@@ -3,6 +3,7 @@ import 'dart:js_interop' as js_interop;
 import 'dart:js_interop_unsafe';
 import 'dart:js_util' as js_util;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:http/http.dart';
@@ -175,6 +176,7 @@ class KdfOperationsWasm implements IKdfOperations {
     try {
       await _ensureLoaded();
 
+      _log('mm2Rpc request (pre-process): $request');
       request['userpass'] = _config.rpcPassword;
 
       final jsResponse = await js_util.promiseToFuture<js_interop.JSObject>(
@@ -184,7 +186,7 @@ class KdfOperationsWasm implements IKdfOperations {
         ),
       );
 
-      print('Response pre-cast: ${js_util.dartify(jsResponse)}');
+      if (kDebugMode) _log('Response pre-cast: ${js_util.dartify(jsResponse)}');
 
       // Convert the JS object to a Dart map and ensure it's a JsonMap
       final response =

--- a/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
+++ b/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
@@ -176,7 +176,7 @@ class KdfOperationsWasm implements IKdfOperations {
     try {
       await _ensureLoaded();
 
-      _log('mm2Rpc request (pre-process): $request');
+      if (kDebugMode) _log('mm2Rpc request (pre-process): $request');
       request['userpass'] = _config.rpcPassword;
 
       final jsResponse = await js_util.promiseToFuture<js_interop.JSObject>(

--- a/packages/komodo_defi_framework/web/res/kdf_wrapper.dart
+++ b/packages/komodo_defi_framework/web/res/kdf_wrapper.dart
@@ -1,5 +1,10 @@
+// ignore_for_file: avoid_dynamic_calls
+
 import 'dart:async';
+// This is a web-specific file, so it's safe to ignore this warning
+// ignore: avoid_web_libraries_in_flutter
 import 'dart:js' as js;
+
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:js/js_util.dart';
@@ -7,12 +12,12 @@ import 'package:js/js_util.dart';
 class KdfPlugin {
   static void registerWith(Registrar registrar) {
     final plugin = KdfPlugin();
+    // ignore: unused_local_variable
     final channel = MethodChannel(
       'komodo_defi_framework/kdf',
       const StandardMethodCodec(),
       registrar,
-    );
-    channel.setMethodCallHandler(plugin.handleMethodCall);
+    )..setMethodCallHandler(plugin.handleMethodCall);
   }
 
   Future<dynamic> handleMethodCall(MethodCall call) async {


### PR DESCRIPTION
Only log pre-cast responses on wasm in debug mode. 

CI integration test log zip size:

- [before integration](https://github.com/KomodoPlatform/komodo-wallet-private/actions/runs/11437890363): 28.5 KB
- [after integration](https://github.com/KomodoPlatform/komodo-wallet-private/actions/runs/11801551026/attempts/1?pr=177): 954 KB (includes debug print statements added to the integration tests, which inflates it slightly)