### PR TITLE
fix(auth_service): hd wallet registration deadlock

### DIFF
--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -28,7 +28,7 @@
     "coins": {
         "fetch_at_build_enabled": true,
         "update_commit_on_build": true,
-        "bundled_coins_repo_commit": "44e8a5b6a8f7612784b362d225fe8b98bf3c5661",
+        "bundled_coins_repo_commit": "ac29808824421ec3e86eceda6caf43fb5b80a7ef",
         "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",
         "coins_repo_content_url": "https://komodoplatform.github.io/coins",
         "coins_repo_branch": "master",

--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -28,7 +28,7 @@
     "coins": {
         "fetch_at_build_enabled": true,
         "update_commit_on_build": true,
-        "bundled_coins_repo_commit": "ec27eef5bf081895268ea409f10634530ffbde06",
+        "bundled_coins_repo_commit": "44e8a5b6a8f7612784b362d225fe8b98bf3c5661",
         "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",
         "coins_repo_content_url": "https://komodoplatform.github.io/coins",
         "coins_repo_branch": "master",

--- a/packages/komodo_defi_sdk/example/web/kdf/res/kdf_wrapper.dart
+++ b/packages/komodo_defi_sdk/example/web/kdf/res/kdf_wrapper.dart
@@ -1,5 +1,10 @@
+// ignore_for_file: avoid_dynamic_calls
+
 import 'dart:async';
+// This is a web-specific file, so it's safe to ignore this warning
+// ignore: avoid_web_libraries_in_flutter
 import 'dart:js' as js;
+
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:js/js_util.dart';
@@ -7,12 +12,12 @@ import 'package:js/js_util.dart';
 class KdfPlugin {
   static void registerWith(Registrar registrar) {
     final plugin = KdfPlugin();
+    // ignore: unused_local_variable
     final channel = MethodChannel(
       'komodo_defi_framework/kdf',
       const StandardMethodCodec(),
       registrar,
-    );
-    channel.setMethodCallHandler(plugin.handleMethodCall);
+    )..setMethodCallHandler(plugin.handleMethodCall);
   }
 
   Future<dynamic> handleMethodCall(MethodCall call) async {


### PR DESCRIPTION
Calling `_runReadOperation` inside a `_runWriteOperation` caused a deadlock (circular reference in this case), since read and write operations cannot coexist when using the `ReadWriteMutex`.

Continuation of incomplete fix in #10 (only fixed legacy registrations, not HD) 

## Changes

- Added a boolean flag to toggle to `getMnenomic` to skip mutex locking when verifying seed bip39 compatibility
- Removed unreferenced functions
- Changed the order of operations in the register function 