### PR TITLE
fix(kdf-wasm-ops): response type conversion and migrate to js_interop

### DIFF
--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -28,7 +28,7 @@
     "coins": {
         "fetch_at_build_enabled": true,
         "update_commit_on_build": true,
-        "bundled_coins_repo_commit": "5c8100dbefe16eb3eec9a672bb6e628ce37ddb57",
+        "bundled_coins_repo_commit": "958e6edd877e9a248eba0777af5ca3bd5196e2ea",
         "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",
         "coins_repo_content_url": "https://komodoplatform.github.io/coins",
         "coins_repo_branch": "master",

--- a/playground/lib/kdf_operations/kdf_operations_server_web.dart
+++ b/playground/lib/kdf_operations/kdf_operations_server_web.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:js_interop';
 // this warning is pointless, since `web` and `js_interop` fail to compile on
 // native platforms, so they aren't safe to import without conditional
 // imports either (yet)
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:js_util' as js_util;
 
 import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
@@ -37,10 +37,10 @@ class KdfHttpServerOperations implements IKdfOperations {
       throw Exception('WebView controller is not available.');
     }
 
-    final jsConfig = js_util.jsify({
+    final jsConfig = {
       'conf': startParams,
       'log_level': logLevel ?? 3,
-    });
+    }.jsify();
 
     try {
       final result = await controller.evaluateJavascript(


### PR DESCRIPTION
## Changes

- Migrate from `dart:js` and `dart:js_util` to `dart:js_interop`
- Fix type conversion of JS response objects
- Improve JS interop and error handling

The original goal was to fix uncaught async errors without a stacktrace, but that appears to be a non-critical bug related to coin activation - breakpoint steps into `activation_strategy_base.dart` (line 122 `yield* strategy.activate(asset, children)`)