### PR TITLE
fix: defi types index

### DIFF
--- a/packages/komodo_defi_types/lib/types.dart
+++ b/packages/komodo_defi_types/lib/types.dart
@@ -25,7 +25,6 @@ export 'src/exceptions/http_exceptions.dart';
 export 'src/generic/result.dart';
 export 'src/generic/sync_status.dart';
 export 'src/komodo_defi_types_base.dart';
-export 'src/legacy/legacy_coin_model.dart';
 export 'src/protocols/base/exceptions.dart';
 export 'src/protocols/base/protocol_class.dart';
 export 'src/protocols/erc20/erc20_protocol.dart';


### PR DESCRIPTION
remove `legacy_coin_model.dart` from the types index, which was causing builds to fail