### PR TITLE
remove unused aws_client dependency

### DIFF
--- a/packages/komodo_defi_framework/pubspec.yaml
+++ b/packages/komodo_defi_framework/pubspec.yaml
@@ -13,7 +13,6 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  aws_client: ^0.6.0
   ffi: ^2.1.2
   flutter:
     sdk: flutter

--- a/playground/pubspec.lock
+++ b/playground/pubspec.lock
@@ -17,14 +17,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
-  aws_client:
-    dependency: transitive
-    description:
-      name: aws_client
-      sha256: "433b3a5ca80eff10744d2403102477662a040b0204c5b31a1d1a1398f91494f0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.0"
   bip39:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Remove unused `aws_client` dependency from `komodo_defi_framework` and `playground`