### PR TITLE
fix(auth_service): legacy wallet bip39 validation

### DIFF
--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -28,7 +28,7 @@
     "coins": {
         "fetch_at_build_enabled": true,
         "update_commit_on_build": true,
-        "bundled_coins_repo_commit": "d7906da4ab0283ea7dcd22d8b5157a8a46eac0f2",
+        "bundled_coins_repo_commit": "642abea7172b81db24b16bffc13783b9a0e400f5",
         "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",
         "coins_repo_content_url": "https://komodoplatform.github.io/coins",
         "coins_repo_branch": "master",

--- a/packages/komodo_defi_local_auth/lib/src/auth/auth_service.dart
+++ b/packages/komodo_defi_local_auth/lib/src/auth/auth_service.dart
@@ -111,9 +111,12 @@ class KdfAuthService implements IAuthService {
       }
 
       final storedUser = await _secureStorage.getUser(walletName);
+      if (storedUser == null) {
+        throw AuthException.notFound();
+      }
 
       // If we know this is not a BIP39 seed, don't allow HD mode
-      if (storedUser?.isBip39Seed == false &&
+      if (storedUser.isBip39Seed == false &&
           options.derivationMethod == DerivationMethod.hdWallet) {
         throw AuthException(
           'Cannot use HD mode with non-BIP39 seed',

--- a/packages/komodo_defi_sdk/example/lib/main.dart
+++ b/packages/komodo_defi_sdk/example/lib/main.dart
@@ -738,10 +738,6 @@ class _KomodoAppState extends State<KomodoApp> {
       return 'Please enter a ${fieldName ?? 'value'}.';
     }
 
-    if (input.contains(RegExp('[<>&]'))) {
-      return "Invalid password: contains '<', '>', or '&'";
-    }
-
     return null;
   }
 


### PR DESCRIPTION
Fixes the login issue reported by @naezith 

Steps to reproduce:
1. Register Iguana (legacy) wallet using a seed phrase
2. Logout
3. Log in to the Iguana wallet in HD mode. 

On `dev`, logging into an Iguana wallet in HD mode fails with a BIP39 validation error. This is because BIP39 validation was only performed for HD wallet registrations.

Changes:
- Perform BIP39 validation for all registrations, but only rethrow `AuthException` if the current mode is HD.
- Remove invalid password validation checks