### PR TITLE
fix(asset-manager): asset ticker initialisation

### DIFF
--- a/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
@@ -97,6 +97,8 @@ class AssetManager implements IAssetProvider {
 
     _orderedCoins.addAll(_coins.all);
 
+    await initTickerIndex();
+
     final currentUser = await _auth.currentUser;
     await _onAuthStateChanged(currentUser);
 


### PR DESCRIPTION
Fixes a runtime error in KW (see in [2521](https://github.com/KomodoPlatform/komodo-wallet/pull/2521)) where the Wallet page fails to load due to legacy ticker index not being initialized