### PR TITLE
fix(transaction-history): re-enable non-hd transaction history support

### DIFF
--- a/packages/komodo_defi_sdk/lib/src/transaction_history/transaction_history_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/transaction_history/transaction_history_manager.dart
@@ -37,7 +37,8 @@ class TransactionHistoryManager implements _TransactionHistoryManager {
     required PubkeyManager pubkeyManager,
     TransactionStorage? storage,
   })  : _storage = storage ?? TransactionStorage.defaultForPlatform(),
-        _strategyFactory = TransactionHistoryStrategyFactory(pubkeyManager);
+        _strategyFactory =
+            TransactionHistoryStrategyFactory(pubkeyManager, _auth);
 
   final ApiClient _client;
   final KomodoDefiLocalAuth _auth;


### PR DESCRIPTION
Re-enables non-HD transaction history support by adding `KomodoDefiLocalAuth` to `V2TransactionStrategy` through dependency injection via `TransactionHistoryStrategyFactory`.