### PR TITLE
fix(transaction-storage): transaction streaming errors and hanging due to storage error

### DIFF
--- a/packages/komodo_defi_local_auth/lib/src/auth/auth_service.dart
+++ b/packages/komodo_defi_local_auth/lib/src/auth/auth_service.dart
@@ -196,8 +196,7 @@ class KdfAuthService implements IAuthService {
 
           // Create new user record if none exists
           final newUser = KdfUser(
-            walletId: WalletId.fromName(name),
-            authOptions: _fallbackAuthOptions,
+            walletId: WalletId.fromName(name, _fallbackAuthOptions),
             isBip39Seed: true, // Default to true until verified otherwise
           );
           await _secureStorage.saveUser(newUser);

--- a/packages/komodo_defi_local_auth/lib/src/auth/auth_service_auth_extension.dart
+++ b/packages/komodo_defi_local_auth/lib/src/auth/auth_service_auth_extension.dart
@@ -54,11 +54,10 @@ extension KdfAuthServiceAuthExtension on KdfAuthService {
       );
     }
 
-    final walletId = WalletId.fromName(config.walletName!);
+    final walletId = WalletId.fromName(config.walletName!, authOptions);
     // ignore: omit_local_variable_types
     KdfUser currentUser = KdfUser(
       walletId: walletId,
-      authOptions: authOptions,
       isBip39Seed: false,
     );
     await _secureStorage.saveUser(currentUser);

--- a/packages/komodo_defi_local_auth/lib/src/komodo_defi_local_auth.dart
+++ b/packages/komodo_defi_local_auth/lib/src/komodo_defi_local_auth.dart
@@ -175,8 +175,12 @@ class KomodoDefiLocalAuth implements KomodoDefiAuth {
     await ensureInitialized();
     await _assertAuthState(false);
 
-    final updatedUser =
-        (await _findUser(walletName)).copyWith(authOptions: options);
+    final user = await _findUser(walletName);
+    final updatedUser = user.copyWith(
+      walletId: user.walletId.copyWith(
+        authOptions: options,
+      ),
+    );
 
     // Save AuthOptions to secure storage by wallet name
     await _secureStorage.saveUser(updatedUser);

--- a/packages/komodo_defi_sdk/lib/src/transaction_history/transaction_history_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/transaction_history/transaction_history_manager.dart
@@ -197,8 +197,6 @@ class TransactionHistoryManager implements _TransactionHistoryManager {
                 ),
         );
 
-        retryCount = 0;
-
         if (response.transactions.isEmpty) {
           hasMore = false;
           continue;

--- a/packages/komodo_defi_sdk/lib/src/transaction_history/transaction_history_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/transaction_history/transaction_history_manager.dart
@@ -105,6 +105,7 @@ class TransactionHistoryManager implements _TransactionHistoryManager {
       // First try to get from local storage
       final localPage = await _storage.getTransactions(
         asset.id,
+        await _getCurrentUser(),
         fromId:
             pagination is TransactionBasedPagination ? pagination.fromId : null,
         pageNumber: pagination is PagePagination ? pagination.pageNumber : null,
@@ -169,6 +170,7 @@ class TransactionHistoryManager implements _TransactionHistoryManager {
     // First try to get any cached transactions
     final localPage = await _storage.getTransactions(
       asset.id,
+      await _getCurrentUser(),
       limit: _maxBatchSize,
     );
 
@@ -263,7 +265,10 @@ class TransactionHistoryManager implements _TransactionHistoryManager {
 
     try {
       final strategy = _strategyFactory.forAsset(asset);
-      var fromId = await _storage.getLatestTransactionId(asset.id);
+      var fromId = await _storage.getLatestTransactionId(
+        asset.id,
+        await _getCurrentUser(),
+      );
       var hasMore = true;
 
       while (hasMore && !_isDisposed) {
@@ -308,7 +313,10 @@ class TransactionHistoryManager implements _TransactionHistoryManager {
   Future<void> clearTransactionHistory(Asset asset) async {
     if (_isDisposed) return;
 
-    await _storage.clearTransactions(asset.id);
+    await _storage.clearTransactions(
+      asset.id,
+      await _getCurrentUser(),
+    );
     _stopPolling(asset.id);
     await _streamControllers[asset.id]?.close();
     _streamControllers.remove(asset.id);
@@ -319,7 +327,10 @@ class TransactionHistoryManager implements _TransactionHistoryManager {
 
     try {
       final strategy = _strategyFactory.forAsset(asset);
-      final lastTx = await _storage.getLatestTransactionId(asset.id);
+      final lastTx = await _storage.getLatestTransactionId(
+        asset.id,
+        await _getCurrentUser(),
+      );
 
       await _rateLimiter.throttle();
 
@@ -368,11 +379,22 @@ class TransactionHistoryManager implements _TransactionHistoryManager {
     }
   }
 
+  Future<KdfUser> _getCurrentUser() async {
+    final currentUser = await _auth.currentUser;
+    if (currentUser == null) {
+      throw StateError('User is not logged in');
+    }
+    return currentUser;
+  }
+
   Future<void> _batchStoreTransactions(List<Transaction> transactions) async {
     if (transactions.isEmpty) return;
 
     try {
-      await _storage.storeTransactions(transactions);
+      await _storage.storeTransactions(
+        transactions,
+        await _getCurrentUser(),
+      );
     } catch (e) {
       throw Exception('Failed to store transactions batch: $e');
     }

--- a/packages/komodo_defi_types/lib/src/auth/auth_options.dart
+++ b/packages/komodo_defi_types/lib/src/auth/auth_options.dart
@@ -1,7 +1,8 @@
+import 'package:equatable/equatable.dart';
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 
-class AuthOptions {
+class AuthOptions extends Equatable {
   const AuthOptions({
     required this.derivationMethod,
   });
@@ -20,4 +21,7 @@ class AuthOptions {
       'derivation_method': derivationMethod.toString(),
     };
   }
+  
+  @override
+  List<Object?> get props => [derivationMethod];
 }

--- a/packages/komodo_defi_types/lib/src/transactions/asset_transaction_history_id.dart
+++ b/packages/komodo_defi_types/lib/src/transactions/asset_transaction_history_id.dart
@@ -6,16 +6,16 @@ import 'package:komodo_defi_types/src/auth/kdf_user.dart';
 /// This is used to store the transaction history in key-value storage without
 /// collisions when using multiple wallets on the same device.
 class AssetTransactionHistoryId extends Equatable {
-  const AssetTransactionHistoryId(this.wallet, this.assetId);
+  const AssetTransactionHistoryId(this.walletId, this.assetId);
 
   /// The wallet for which the transaction history is stored (cached). This is
   /// used to uniquely identify the transaction history for a given wallet and
   /// asset.
-  final KdfUser wallet;
+  final WalletId walletId;
 
   /// The asset for which the transaction history is stored (cached).
   final AssetId assetId;
 
   @override
-  List<Object?> get props => [wallet, assetId];
+  List<Object?> get props => [walletId, assetId];
 }

--- a/packages/komodo_defi_types/lib/src/transactions/asset_transaction_history_id.dart
+++ b/packages/komodo_defi_types/lib/src/transactions/asset_transaction_history_id.dart
@@ -1,0 +1,21 @@
+import 'package:equatable/equatable.dart';
+import 'package:komodo_defi_types/src/assets/asset_id.dart';
+import 'package:komodo_defi_types/src/auth/kdf_user.dart';
+
+/// Compound unique for the transaction history of an asset for a given wallet.
+/// This is used to store the transaction history in key-value storage without
+/// collisions when using multiple wallets on the same device.
+class AssetTransactionHistoryId extends Equatable {
+  const AssetTransactionHistoryId(this.wallet, this.assetId);
+
+  /// The wallet for which the transaction history is stored (cached). This is
+  /// used to uniquely identify the transaction history for a given wallet and
+  /// asset.
+  final KdfUser wallet;
+
+  /// The asset for which the transaction history is stored (cached).
+  final AssetId assetId;
+
+  @override
+  List<Object?> get props => [wallet, assetId];
+}

--- a/packages/komodo_defi_types/lib/src/types.dart
+++ b/packages/komodo_defi_types/lib/src/types.dart
@@ -44,6 +44,7 @@ export 'public_key/pubkey.dart';
 export 'public_key/pubkey_strategy.dart';
 export 'public_key/token_balance_map.dart';
 export 'public_key/wallet_balance.dart';
+export 'transactions/asset_transaction_history_id.dart';
 export 'transactions/balance_changes.dart';
 export 'transactions/fee_info.dart';
 export 'transactions/transaction.dart';


### PR DESCRIPTION
- fix infinite loop in transaction stream retry logic
- refactor storage interface to use combination of wallet and asset as ID
- fix transaction storage error where new transactions streamed in are not available in the `_compareTransactions` function, resulting in transaction storage exceptions.