### PR TITLE
build: rename libraries from 'mm2' to 'kdf'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ contrib/coins_config.json
 
 # api native library
 libmm2.a
+libkdf.a
 libmm2.dylib
 libkdflib.a
 libkdflib.dylib

--- a/packages/komodo_defi_framework/ios/komodo_defi_framework.podspec
+++ b/packages/komodo_defi_framework/ios/komodo_defi_framework.podspec
@@ -28,14 +28,14 @@ A new Flutter FFI plugin project.
     'SystemConfiguration',
   ]
 
-  s.vendored_libraries = 'libmm2.a'
+  s.vendored_libraries = 'libkdf.a'
   # s.vendored_libraries = 'libkdflib.dylib'
 
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
     'OTHER_LDFLAGS' => [
-      '-force_load "$(PODS_TARGET_SRCROOT)/libmm2.a"',
+      '-force_load "$(PODS_TARGET_SRCROOT)/libkdf.a"',
       '-framework SystemConfiguration',
     ],
     # # Add rpath to ensure dylib can be found at runtime

--- a/packages/komodo_defi_framework/macos/komodo_defi_framework.podspec.staticlib
+++ b/packages/komodo_defi_framework/macos/komodo_defi_framework.podspec.staticlib
@@ -24,7 +24,7 @@ A new Flutter FFI plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
-  # s.vendored_libraries = 'Frameworks/libmm2.a'
+  # s.vendored_libraries = 'Frameworks/libkdf.a'
   # s.vendored_libraries = ['Frameworks/libkdflib.a']
   s.vendored_libraries = ['Frameworks/*.a']
   # Exclude i386 and arm64 from iOS Simulator build

--- a/packages/komodo_defi_framework/src/CMakeLists.txt
+++ b/packages/komodo_defi_framework/src/CMakeLists.txt
@@ -18,7 +18,7 @@ target_compile_definitions(komodo_defi_framework PUBLIC DART_SHARED_LIB)
 
 if(ANDROID)
   set(KDFLIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../android/app/src/main/cpp/libs")
-  set(KDFLIB_PATH "${KDFLIB_DIR}/${ANDROID_ABI}/libmm2.a")
+  set(KDFLIB_PATH "${KDFLIB_DIR}/${ANDROID_ABI}/libkdf.a")
 
   find_library(KDFLIB_PATH mm2 PATHS "${CMAKE_SOURCE_DIR}/path/to/library/directory" NO_DEFAULT_PATH )
 


### PR DESCRIPTION
Fixes Android build error by enforcing consistent filenames regardless of download source. All executables and libraries are now renamed from 'mm2' to 'kdf' with a `.replaceAll` operation on the filename.