### PR TITLE
feat: runtime coin updates 

### DIFF
--- a/packages/komodo_coin_updates/.gitignore
+++ b/packages/komodo_coin_updates/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/komodo_coin_updates/CHANGELOG.md
+++ b/packages/komodo_coin_updates/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.0.1
+
+- Initial version.

--- a/packages/komodo_coin_updates/README.md
+++ b/packages/komodo_coin_updates/README.md
@@ -1,0 +1,71 @@
+# Komodo Coin Updater
+
+This package provides the funcionality to update the coins list and configuration files for the Komodo Platform at runtime.
+
+## Usage
+
+To use this package, you need to add `komodo_coin_updater` to your `pubspec.yaml` file.
+
+```yaml
+dependencies:
+  komodo_coin_updater: ^1.0.0
+```
+
+### Initialize the package
+
+Then you can use the `KomodoCoinUpdater` class to initialize the package.
+
+```dart
+import 'package:komodo_coin_updater/komodo_coin_updater.dart';
+
+void main() async {
+  await KomodoCoinUpdater.ensureInitialized("path/to/komodo/coin/files");
+}
+```
+
+### Provider
+
+The coins provider is responsible for fetching the coins list and configuration files from GitHub.
+
+```dart
+import 'package:komodo_coin_updater/komodo_coin_updater.dart';
+
+Future<void> main() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    await KomodoCoinUpdater.ensureInitialized("path/to/komodo/coin/files");
+
+    final provider = const CoinConfigProvider();
+    final coins = await provider.getLatestCoins();
+    final coinsConfigs = await provider.getLatestCoinConfigs();
+}
+```
+
+### Repository
+
+The repository is responsible for managing the coins list and configuration files, fetching from GitHub and persisting to storage.
+
+```dart
+import 'package:komodo_coin_updater/komodo_coin_updater.dart';
+
+Future<void> main() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    await KomodoCoinUpdater.ensureInitialized("path/to/komodo/coin/files");
+
+    final repository = CoinConfigRepository(
+        api: const CoinConfigProvider(),
+        storageProvider: CoinConfigStorageProvider.withDefaults(),
+    ); 
+    
+    // Load the coin configuration if it is saved, otherwise update it 
+    if(await repository.coinConfigExists()) {
+        if (await repository.isLatestCommit()) {
+            await repository.loadCoinConfigs();
+        } else {
+            await repository.updateCoinConfig();
+        }
+    }
+    else {
+        await repository.updateCoinConfig();
+    }
+}
+```

--- a/packages/komodo_coin_updates/README.md
+++ b/packages/komodo_coin_updates/README.md
@@ -1,7 +1,6 @@
 # Komodo Coin Updater
 
-This package provides the funcionality to update the coins list and configuration files for the Komodo Platform at runtime.
-
+This package provides the functionality to update the coins list and configuration files for the Komodo Platform at runtime.
 ## Usage
 
 To use this package, you need to add `komodo_coin_updater` to your `pubspec.yaml` file.

--- a/packages/komodo_coin_updates/example/komodo_coin_updates_example.dart
+++ b/packages/komodo_coin_updates/example/komodo_coin_updates_example.dart
@@ -1,0 +1,4 @@
+void main() {
+  // TODO(Francois): implement this
+  throw UnimplementedError();
+}

--- a/packages/komodo_coin_updates/lib/komodo_coin_updates.dart
+++ b/packages/komodo_coin_updates/lib/komodo_coin_updates.dart
@@ -1,0 +1,8 @@
+/// Support for doing something awesome.
+///
+/// More dartdocs go here.
+library;
+
+export 'src/data/data.dart';
+export 'src/komodo_coin_updater.dart';
+export 'src/models/models.dart';

--- a/packages/komodo_coin_updates/lib/src/data/coin_config_provider.dart
+++ b/packages/komodo_coin_updates/lib/src/data/coin_config_provider.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../models/models.dart';
+
+/// A provider that fetches the coins and coin configs from the repository.
+/// The repository is hosted on GitHub.
+/// The repository contains a list of coins and a map of coin configs.
+class CoinConfigProvider {
+  CoinConfigProvider({
+    this.branch = 'master',
+    this.coinsGithubContentUrl =
+        'https://raw.githubusercontent.com/KomodoPlatform/coins',
+    this.coinsGithubApiUrl =
+        'https://api.github.com/repos/KomodoPlatform/coins',
+    this.coinsPath = 'coins',
+    this.coinsConfigPath = 'utils/coins_config_unfiltered.json',
+  });
+
+  factory CoinConfigProvider.fromConfig(RuntimeUpdateConfig config) {
+    // TODO(Francois): derive all the values from the config
+    return CoinConfigProvider(
+      branch: config.coinsRepoBranch,
+    );
+  }
+
+  final String branch;
+  final String coinsGithubContentUrl;
+  final String coinsGithubApiUrl;
+  final String coinsPath;
+  final String coinsConfigPath;
+
+  /// Fetches the coins from the repository.
+  /// [commit] is the commit hash to fetch the coins from.
+  /// If [commit] is not provided, it will fetch the coins from the latest commit.
+  /// Returns a list of [Coin] objects.
+  /// Throws an [Exception] if the request fails.
+  Future<List<Coin>> getCoins(String commit) async {
+    final Uri url = _contentUri(coinsPath, branchOrCommit: commit);
+    final http.Response response = await http.get(url);
+    final List<dynamic> items = jsonDecode(response.body) as List<dynamic>;
+    return items
+        .map((dynamic e) => Coin.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Fetches the coins from the repository.
+  /// Returns a list of [Coin] objects.
+  /// Throws an [Exception] if the request fails.
+  Future<List<Coin>> getLatestCoins() async {
+    return getCoins(branch);
+  }
+
+  /// Fetches the coin configs from the repository.
+  /// [commit] is the commit hash to fetch the coin configs from.
+  /// If [commit] is not provided, it will fetch the coin configs
+  /// from the latest commit.
+  /// Returns a map of [CoinConfig] objects.
+  /// Throws an [Exception] if the request fails.
+  /// The key of the map is the coin symbol.
+  Future<Map<String, CoinConfig>> getCoinConfigs(String commit) async {
+    final Uri url = _contentUri(coinsConfigPath, branchOrCommit: commit);
+    final http.Response response = await http.get(url);
+    final Map<String, dynamic> items =
+        jsonDecode(response.body) as Map<String, dynamic>;
+    return <String, CoinConfig>{
+      for (final String key in items.keys)
+        key: CoinConfig.fromJson(items[key] as Map<String, dynamic>),
+    };
+  }
+
+  /// Fetches the latest coin configs from the repository.
+  /// Returns a map of [CoinConfig] objects.
+  /// Throws an [Exception] if the request fails.
+  Future<Map<String, CoinConfig>> getLatestCoinConfigs() async {
+    return getCoinConfigs(branch);
+  }
+
+  /// Fetches the latest commit hash from the repository.
+  /// Returns the latest commit hash.
+  /// Throws an [Exception] if the request fails.
+  Future<String> getLatestCommit() async {
+    final http.Client client = http.Client();
+    final Uri url = Uri.parse('$coinsGithubApiUrl/branches/$branch');
+    final Map<String, String> header = <String, String>{
+      'Accept': 'application/vnd.github+json',
+    };
+    final http.Response response = await client.get(url, headers: header);
+
+    final Map<String, dynamic> json =
+        jsonDecode(response.body) as Map<String, dynamic>;
+    final Map<String, dynamic> commit = json['commit'] as Map<String, dynamic>;
+    final String latestCommitHash = commit['sha'] as String;
+    return latestCommitHash;
+  }
+
+  Uri _contentUri(String path, {String? branchOrCommit}) {
+    branchOrCommit ??= branch;
+    return Uri.parse('$coinsGithubContentUrl/$branch/$path');
+  }
+}

--- a/packages/komodo_coin_updates/lib/src/data/coin_config_provider.dart
+++ b/packages/komodo_coin_updates/lib/src/data/coin_config_provider.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
-import '../models/models.dart';
+import 'package:komodo_coin_updates/src/models/models.dart';
 
 /// A provider that fetches the coins and coin configs from the repository.
 /// The repository is hosted on GitHub.
@@ -20,9 +20,7 @@ class CoinConfigProvider {
 
   factory CoinConfigProvider.fromConfig(RuntimeUpdateConfig config) {
     // TODO(Francois): derive all the values from the config
-    return CoinConfigProvider(
-      branch: config.coinsRepoBranch,
-    );
+    return CoinConfigProvider(branch: config.coinsRepoBranch);
   }
 
   final String branch;
@@ -37,9 +35,9 @@ class CoinConfigProvider {
   /// Returns a list of [Coin] objects.
   /// Throws an [Exception] if the request fails.
   Future<List<Coin>> getCoins(String commit) async {
-    final Uri url = _contentUri(coinsPath, branchOrCommit: commit);
-    final http.Response response = await http.get(url);
-    final List<dynamic> items = jsonDecode(response.body) as List<dynamic>;
+    final url = _contentUri(coinsPath, branchOrCommit: commit);
+    final response = await http.get(url);
+    final items = jsonDecode(response.body) as List<dynamic>;
     return items
         .map((dynamic e) => Coin.fromJson(e as Map<String, dynamic>))
         .toList();
@@ -60,10 +58,9 @@ class CoinConfigProvider {
   /// Throws an [Exception] if the request fails.
   /// The key of the map is the coin symbol.
   Future<Map<String, CoinConfig>> getCoinConfigs(String commit) async {
-    final Uri url = _contentUri(coinsConfigPath, branchOrCommit: commit);
-    final http.Response response = await http.get(url);
-    final Map<String, dynamic> items =
-        jsonDecode(response.body) as Map<String, dynamic>;
+    final url = _contentUri(coinsConfigPath, branchOrCommit: commit);
+    final response = await http.get(url);
+    final items = jsonDecode(response.body) as Map<String, dynamic>;
     return <String, CoinConfig>{
       for (final String key in items.keys)
         key: CoinConfig.fromJson(items[key] as Map<String, dynamic>),
@@ -81,17 +78,14 @@ class CoinConfigProvider {
   /// Returns the latest commit hash.
   /// Throws an [Exception] if the request fails.
   Future<String> getLatestCommit() async {
-    final http.Client client = http.Client();
-    final Uri url = Uri.parse('$coinsGithubApiUrl/branches/$branch');
-    final Map<String, String> header = <String, String>{
-      'Accept': 'application/vnd.github+json',
-    };
-    final http.Response response = await client.get(url, headers: header);
+    final client = http.Client();
+    final url = Uri.parse('$coinsGithubApiUrl/branches/$branch');
+    final header = <String, String>{'Accept': 'application/vnd.github+json'};
+    final response = await client.get(url, headers: header);
 
-    final Map<String, dynamic> json =
-        jsonDecode(response.body) as Map<String, dynamic>;
-    final Map<String, dynamic> commit = json['commit'] as Map<String, dynamic>;
-    final String latestCommitHash = commit['sha'] as String;
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    final commit = json['commit'] as Map<String, dynamic>;
+    final latestCommitHash = commit['sha'] as String;
     return latestCommitHash;
   }
 

--- a/packages/komodo_coin_updates/lib/src/data/coin_config_repository.dart
+++ b/packages/komodo_coin_updates/lib/src/data/coin_config_repository.dart
@@ -1,9 +1,8 @@
+import 'package:komodo_coin_updates/komodo_coin_updates.dart';
+import 'package:komodo_coin_updates/src/models/coin_info.dart';
 import 'package:komodo_coin_updates/src/persistence/hive/hive.dart';
 import 'package:komodo_coin_updates/src/persistence/persisted_types.dart';
 import 'package:komodo_coin_updates/src/persistence/persistence_provider.dart';
-
-import '../../komodo_coin_updates.dart';
-import '../models/coin_info.dart';
 
 /// A repository that fetches the coins and coin configs from the provider and
 /// stores them in the storage provider.
@@ -23,13 +22,11 @@ class CoinConfigRepository implements CoinConfigStorage {
   /// The default databases are HiveLazyBoxProvider.
   /// The default databases are named 'coins' and 'coins_settings'.
   CoinConfigRepository.withDefaults(RuntimeUpdateConfig config)
-      : coinConfigProvider = CoinConfigProvider.fromConfig(config),
-        coinsDatabase = HiveLazyBoxProvider<String, CoinInfo>(
-          name: 'coins',
-        ),
-        coinSettingsDatabase = HiveBoxProvider<String, PersistedString>(
-          name: 'coins_settings',
-        );
+    : coinConfigProvider = CoinConfigProvider.fromConfig(config),
+      coinsDatabase = HiveLazyBoxProvider<String, CoinInfo>(name: 'coins'),
+      coinSettingsDatabase = HiveBoxProvider<String, PersistedString>(
+        name: 'coins_settings',
+      );
 
   /// The provider that fetches the coins and coin configs.
   final CoinConfigProvider coinConfigProvider;
@@ -50,16 +47,15 @@ class CoinConfigRepository implements CoinConfigStorage {
   Future<void> updateCoinConfig({
     List<String> excludedAssets = const <String>[],
   }) async {
-    final List<Coin> coins = await coinConfigProvider.getLatestCoins();
-    final Map<String, CoinConfig> coinConfig =
-        await coinConfigProvider.getLatestCoinConfigs();
+    final coins = await coinConfigProvider.getLatestCoins();
+    final coinConfig = await coinConfigProvider.getLatestCoinConfigs();
 
     await saveCoinData(coins, coinConfig, _latestCommit ?? '');
   }
 
   @override
   Future<bool> isLatestCommit() async {
-    final String? commit = await getCurrentCommit();
+    final commit = await getCurrentCommit();
     if (commit != null) {
       _latestCommit = await coinConfigProvider.getLatestCommit();
       return commit == _latestCommit;
@@ -71,7 +67,7 @@ class CoinConfigRepository implements CoinConfigStorage {
   Future<List<Coin>?> getCoins({
     List<String> excludedAssets = const <String>[],
   }) async {
-    final List<CoinInfo?> result = await coinsDatabase.getAll();
+    final result = await coinsDatabase.getAll();
     return result
         .where(
           (CoinInfo? coin) =>
@@ -90,12 +86,13 @@ class CoinConfigRepository implements CoinConfigStorage {
   Future<Map<String, CoinConfig>?> getCoinConfigs({
     List<String> excludedAssets = const <String>[],
   }) async {
-    final List<CoinConfig> coinConfigs = (await coinsDatabase.getAll())
-        .where((CoinInfo? e) => e != null && e.coinConfig != null)
-        .cast<CoinInfo>()
-        .map((CoinInfo e) => e.coinConfig)
-        .cast<CoinConfig>()
-        .toList();
+    final coinConfigs =
+        (await coinsDatabase.getAll())
+            .where((CoinInfo? e) => e != null && e.coinConfig != null)
+            .cast<CoinInfo>()
+            .map((CoinInfo e) => e.coinConfig)
+            .cast<CoinConfig>()
+            .toList();
 
     return <String, CoinConfig>{
       for (final CoinConfig coinConfig in coinConfigs)
@@ -110,9 +107,9 @@ class CoinConfigRepository implements CoinConfigStorage {
 
   @override
   Future<String?> getCurrentCommit() async {
-    return coinSettingsDatabase
-        .get(coinsCommitKey)
-        .then((PersistedString? persistedString) {
+    return coinSettingsDatabase.get(coinsCommitKey).then((
+      PersistedString? persistedString,
+    ) {
       return persistedString?.value;
     });
   }
@@ -123,8 +120,8 @@ class CoinConfigRepository implements CoinConfigStorage {
     Map<String, CoinConfig> coinConfig,
     String commit,
   ) async {
-    final Map<String, CoinInfo> combinedCoins = <String, CoinInfo>{};
-    for (final Coin coin in coins) {
+    final combinedCoins = <String, CoinInfo>{};
+    for (final coin in coins) {
       combinedCoins[coin.coin] = CoinInfo(
         coin: coin,
         coinConfig: coinConfig[coin.coin],
@@ -147,13 +144,16 @@ class CoinConfigRepository implements CoinConfigStorage {
     Map<String, dynamic> coinConfig,
     String commit,
   ) async {
-    final Map<String, CoinInfo> combinedCoins = <String, CoinInfo>{};
+    final combinedCoins = <String, CoinInfo>{};
     for (final dynamic coin in coins) {
       // ignore: avoid_dynamic_calls
-      final String coinAbbr = coin['coin'] as String;
-      final CoinConfig? config = coinConfig[coinAbbr] != null
-          ? CoinConfig.fromJson(coinConfig[coinAbbr] as Map<String, dynamic>)
-          : null;
+      final coinAbbr = coin['coin'] as String;
+      final config =
+          coinConfig[coinAbbr] != null
+              ? CoinConfig.fromJson(
+                coinConfig[coinAbbr] as Map<String, dynamic>,
+              )
+              : null;
       combinedCoins[coinAbbr] = CoinInfo(
         coin: Coin.fromJson(coin as Map<String, dynamic>),
         coinConfig: config,

--- a/packages/komodo_coin_updates/lib/src/data/coin_config_repository.dart
+++ b/packages/komodo_coin_updates/lib/src/data/coin_config_repository.dart
@@ -1,0 +1,164 @@
+import 'package:komodo_persistence_layer/komodo_persistence_layer.dart';
+
+import '../../komodo_coin_updates.dart';
+import '../models/coin_info.dart';
+
+/// A repository that fetches the coins and coin configs from the provider and
+/// stores them in the storage provider.
+class CoinConfigRepository implements CoinConfigStorage {
+  /// Creates a coin config repository.
+  /// [coinConfigProvider] is the provider that fetches the coins and coin configs.
+  /// [coinsDatabase] is the database that stores the coins and their configs.
+  /// [coinSettingsDatabase] is the database that stores the coin settings
+  /// (i.e. current commit hash).
+  CoinConfigRepository({
+    required this.coinConfigProvider,
+    required this.coinsDatabase,
+    required this.coinSettingsDatabase,
+  });
+
+  /// Creates a coin config storage provider with default databases.
+  /// The default databases are HiveLazyBoxProvider.
+  /// The default databases are named 'coins' and 'coins_settings'.
+  CoinConfigRepository.withDefaults(RuntimeUpdateConfig config)
+      : coinConfigProvider = CoinConfigProvider.fromConfig(config),
+        coinsDatabase = HiveLazyBoxProvider<String, CoinInfo>(
+          name: 'coins',
+        ),
+        coinSettingsDatabase = HiveBoxProvider<String, PersistedString>(
+          name: 'coins_settings',
+        );
+
+  /// The provider that fetches the coins and coin configs.
+  final CoinConfigProvider coinConfigProvider;
+
+  /// The database that stores the coins. The key is the coin id.
+  final PersistenceProvider<String, CoinInfo> coinsDatabase;
+
+  /// The database that stores the coin settings. The key is the coin settings key.
+  final PersistenceProvider<String, PersistedString> coinSettingsDatabase;
+
+  /// The key for the coins commit. The value is the commit hash.
+  final String coinsCommitKey = 'coins_commit';
+
+  String? _latestCommit;
+
+  /// Updates the coin configs from the provider and stores them in the storage provider.
+  /// Throws an [Exception] if the request fails.
+  Future<void> updateCoinConfig({
+    List<String> excludedAssets = const <String>[],
+  }) async {
+    final List<Coin> coins = await coinConfigProvider.getLatestCoins();
+    final Map<String, CoinConfig> coinConfig =
+        await coinConfigProvider.getLatestCoinConfigs();
+
+    await saveCoinData(coins, coinConfig, _latestCommit ?? '');
+  }
+
+  @override
+  Future<bool> isLatestCommit() async {
+    final String? commit = await getCurrentCommit();
+    if (commit != null) {
+      _latestCommit = await coinConfigProvider.getLatestCommit();
+      return commit == _latestCommit;
+    }
+    return false;
+  }
+
+  @override
+  Future<List<Coin>?> getCoins({
+    List<String> excludedAssets = const <String>[],
+  }) async {
+    final List<CoinInfo?> result = await coinsDatabase.getAll();
+    return result
+        .where(
+          (CoinInfo? coin) =>
+              coin != null && !excludedAssets.contains(coin.coin.coin),
+        )
+        .map((CoinInfo? coin) => coin!.coin)
+        .toList();
+  }
+
+  @override
+  Future<Coin?> getCoin(String coinId) async {
+    return (await coinsDatabase.get(coinId))!.coin;
+  }
+
+  @override
+  Future<Map<String, CoinConfig>?> getCoinConfigs({
+    List<String> excludedAssets = const <String>[],
+  }) async {
+    final List<CoinConfig> coinConfigs = (await coinsDatabase.getAll())
+        .where((CoinInfo? e) => e != null && e.coinConfig != null)
+        .cast<CoinInfo>()
+        .map((CoinInfo e) => e.coinConfig)
+        .cast<CoinConfig>()
+        .toList();
+
+    return <String, CoinConfig>{
+      for (final CoinConfig coinConfig in coinConfigs)
+        coinConfig.primaryKey: coinConfig,
+    };
+  }
+
+  @override
+  Future<CoinConfig?> getCoinConfig(String coinId) async {
+    return (await coinsDatabase.get(coinId))!.coinConfig;
+  }
+
+  @override
+  Future<String?> getCurrentCommit() async {
+    return coinSettingsDatabase
+        .get(coinsCommitKey)
+        .then((PersistedString? persistedString) {
+      return persistedString?.value;
+    });
+  }
+
+  @override
+  Future<void> saveCoinData(
+    List<Coin> coins,
+    Map<String, CoinConfig> coinConfig,
+    String commit,
+  ) async {
+    final Map<String, CoinInfo> combinedCoins = <String, CoinInfo>{};
+    for (final Coin coin in coins) {
+      combinedCoins[coin.coin] = CoinInfo(
+        coin: coin,
+        coinConfig: coinConfig[coin.coin],
+      );
+    }
+
+    await coinsDatabase.insertAll(combinedCoins.values.toList());
+    await coinSettingsDatabase.insert(PersistedString(coinsCommitKey, commit));
+    _latestCommit = _latestCommit ?? await coinConfigProvider.getLatestCommit();
+  }
+
+  @override
+  Future<bool> coinConfigExists() async {
+    return await coinsDatabase.exists() && await coinSettingsDatabase.exists();
+  }
+
+  @override
+  Future<void> saveRawCoinData(
+    List<dynamic> coins,
+    Map<String, dynamic> coinConfig,
+    String commit,
+  ) async {
+    final Map<String, CoinInfo> combinedCoins = <String, CoinInfo>{};
+    for (final dynamic coin in coins) {
+      // ignore: avoid_dynamic_calls
+      final String coinAbbr = coin['coin'] as String;
+      final CoinConfig? config = coinConfig[coinAbbr] != null
+          ? CoinConfig.fromJson(coinConfig[coinAbbr] as Map<String, dynamic>)
+          : null;
+      combinedCoins[coinAbbr] = CoinInfo(
+        coin: Coin.fromJson(coin as Map<String, dynamic>),
+        coinConfig: config,
+      );
+    }
+
+    await coinsDatabase.insertAll(combinedCoins.values.toList());
+    await coinSettingsDatabase.insert(PersistedString(coinsCommitKey, commit));
+  }
+}

--- a/packages/komodo_coin_updates/lib/src/data/coin_config_repository.dart
+++ b/packages/komodo_coin_updates/lib/src/data/coin_config_repository.dart
@@ -1,4 +1,6 @@
-import 'package:komodo_persistence_layer/komodo_persistence_layer.dart';
+import 'package:komodo_coin_updates/src/persistence/hive/hive.dart';
+import 'package:komodo_coin_updates/src/persistence/persisted_types.dart';
+import 'package:komodo_coin_updates/src/persistence/persistence_provider.dart';
 
 import '../../komodo_coin_updates.dart';
 import '../models/coin_info.dart';

--- a/packages/komodo_coin_updates/lib/src/data/coin_config_storage.dart
+++ b/packages/komodo_coin_updates/lib/src/data/coin_config_storage.dart
@@ -1,5 +1,5 @@
-import '../models/coin.dart';
-import '../models/coin_config.dart';
+import 'package:komodo_coin_updates/src/models/coin.dart';
+import 'package:komodo_coin_updates/src/models/coin_config.dart';
 
 /// A storage provider that fetches the coins and coin configs from the storage.
 /// The storage provider is responsible for fetching the coins and coin configs

--- a/packages/komodo_coin_updates/lib/src/data/coin_config_storage.dart
+++ b/packages/komodo_coin_updates/lib/src/data/coin_config_storage.dart
@@ -1,0 +1,67 @@
+import '../models/coin.dart';
+import '../models/coin_config.dart';
+
+/// A storage provider that fetches the coins and coin configs from the storage.
+/// The storage provider is responsible for fetching the coins and coin configs
+/// from the storage and saving the coins and coin configs to the storage.
+abstract class CoinConfigStorage {
+  /// Fetches the coins from the storage provider.
+  /// Returns a list of [Coin] objects.
+  /// Throws an [Exception] if the request fails.
+  Future<List<Coin>?> getCoins();
+
+  /// Fetches the specified coin from the storage provider.
+  /// [coinId] is the coin symbol.
+  /// Returns a [Coin] object.
+  /// Throws an [Exception] if the request fails.
+  Future<Coin?> getCoin(String coinId);
+
+  /// Fetches the coin configs from the storage provider.
+  /// Returns a map of [CoinConfig] objects.
+  /// Throws an [Exception] if the request fails.
+  Future<Map<String, CoinConfig>?> getCoinConfigs();
+
+  /// Fetches the specified coin config from the storage provider.
+  /// [coinId] is the coin symbol.
+  /// Returns a [CoinConfig] object.
+  /// Throws an [Exception] if the request fails.
+  Future<CoinConfig?> getCoinConfig(String coinId);
+
+  /// Checks if the latest commit is the same as the current commit.
+  /// Returns `true` if the latest commit is the same as the current commit,
+  /// otherwise `false`.
+  /// Throws an [Exception] if the request fails.
+  Future<bool> isLatestCommit();
+
+  /// Fetches the current commit hash.
+  /// Returns the commit hash as a [String].
+  /// Throws an [Exception] if the request fails.
+  Future<String?> getCurrentCommit();
+
+  /// Checks if the coin configs are saved in the storage provider.
+  /// Returns `true` if the coin configs are saved, otherwise `false`.
+  /// Throws an [Exception] if the request fails.
+  Future<bool> coinConfigExists();
+
+  /// Saves the coin data to the storage provider.
+  /// [coins] is a list of [Coin] objects.
+  /// [coinConfig] is a map of [CoinConfig] objects.
+  /// [commit] is the commit hash.
+  /// Throws an [Exception] if the request fails.
+  Future<void> saveCoinData(
+    List<Coin> coins,
+    Map<String, CoinConfig> coinConfig,
+    String commit,
+  );
+
+  /// Saves the raw coin data to the storage provider.
+  /// [coins] is a list of [Coin] objects in raw JSON `dynamic` form.
+  /// [coinConfig] is a map of [CoinConfig] objects in raw JSON `dynamic` form.
+  /// [commit] is the commit hash.
+  /// Throws an [Exception] if the request fails.
+  Future<void> saveRawCoinData(
+    List<dynamic> coins,
+    Map<String, dynamic> coinConfig,
+    String commit,
+  );
+}

--- a/packages/komodo_coin_updates/lib/src/data/data.dart
+++ b/packages/komodo_coin_updates/lib/src/data/data.dart
@@ -1,0 +1,3 @@
+export 'coin_config_provider.dart';
+export 'coin_config_repository.dart';
+export 'coin_config_storage.dart';

--- a/packages/komodo_coin_updates/lib/src/komodo_coin_updater.dart
+++ b/packages/komodo_coin_updates/lib/src/komodo_coin_updater.dart
@@ -1,8 +1,7 @@
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:komodo_coin_updates/src/models/coin_info.dart';
+import 'package:komodo_coin_updates/src/models/models.dart';
 import 'package:komodo_coin_updates/src/persistence/persisted_types.dart';
-
-import 'models/coin_info.dart';
-import 'models/models.dart';
 
 class KomodoCoinUpdater {
   static Future<void> ensureInitialized(String appFolder) async {

--- a/packages/komodo_coin_updates/lib/src/komodo_coin_updater.dart
+++ b/packages/komodo_coin_updates/lib/src/komodo_coin_updater.dart
@@ -1,7 +1,5 @@
 import 'package:hive_flutter/hive_flutter.dart';
-import 'package:komodo_coin_updates/src/persistence/hive/hive.dart';
 import 'package:komodo_coin_updates/src/persistence/persisted_types.dart';
-import 'package:komodo_coin_updates/src/persistence/persistence_provider.dart';
 
 import 'models/coin_info.dart';
 import 'models/models.dart';

--- a/packages/komodo_coin_updates/lib/src/komodo_coin_updater.dart
+++ b/packages/komodo_coin_updates/lib/src/komodo_coin_updater.dart
@@ -1,5 +1,7 @@
 import 'package:hive_flutter/hive_flutter.dart';
-import 'package:komodo_persistence_layer/komodo_persistence_layer.dart';
+import 'package:komodo_coin_updates/src/persistence/hive/hive.dart';
+import 'package:komodo_coin_updates/src/persistence/persisted_types.dart';
+import 'package:komodo_coin_updates/src/persistence/persistence_provider.dart';
 
 import 'models/coin_info.dart';
 import 'models/models.dart';

--- a/packages/komodo_coin_updates/lib/src/komodo_coin_updater.dart
+++ b/packages/komodo_coin_updates/lib/src/komodo_coin_updater.dart
@@ -1,0 +1,34 @@
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:komodo_persistence_layer/komodo_persistence_layer.dart';
+
+import 'models/coin_info.dart';
+import 'models/models.dart';
+
+class KomodoCoinUpdater {
+  static Future<void> ensureInitialized(String appFolder) async {
+    await Hive.initFlutter(appFolder);
+    initializeAdapters();
+  }
+
+  static void ensureInitializedIsolate(String fullAppFolderPath) {
+    Hive.init(fullAppFolderPath);
+    initializeAdapters();
+  }
+
+  static void initializeAdapters() {
+    Hive.registerAdapter(AddressFormatAdapter());
+    Hive.registerAdapter(CheckPointBlockAdapter());
+    Hive.registerAdapter(CoinAdapter());
+    Hive.registerAdapter(CoinConfigAdapter());
+    Hive.registerAdapter(CoinInfoAdapter());
+    Hive.registerAdapter(ConsensusParamsAdapter());
+    Hive.registerAdapter(ContactAdapter());
+    Hive.registerAdapter(ElectrumAdapter());
+    Hive.registerAdapter(LinksAdapter());
+    Hive.registerAdapter(NodeAdapter());
+    Hive.registerAdapter(PersistedStringAdapter());
+    Hive.registerAdapter(ProtocolAdapter());
+    Hive.registerAdapter(ProtocolDataAdapter());
+    Hive.registerAdapter(RpcUrlAdapter());
+  }
+}

--- a/packages/komodo_coin_updates/lib/src/models/adapters/address_format_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/address_format_adapter.dart
@@ -1,0 +1,38 @@
+part of '../address_format.dart';
+
+class AddressFormatAdapter extends TypeAdapter<AddressFormat> {
+  @override
+  final int typeId = 3;
+
+  @override
+  AddressFormat read(BinaryReader reader) {
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return AddressFormat(
+      format: fields[0] as String?,
+      network: fields[1] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, AddressFormat obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.format)
+      ..writeByte(1)
+      ..write(obj.network);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AddressFormatAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/packages/komodo_coin_updates/lib/src/models/adapters/address_format_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/address_format_adapter.dart
@@ -6,8 +6,8 @@ class AddressFormatAdapter extends TypeAdapter<AddressFormat> {
 
   @override
   AddressFormat read(BinaryReader reader) {
-    final int numOfFields = reader.readByte();
-    final Map<int, dynamic> fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return AddressFormat(

--- a/packages/komodo_coin_updates/lib/src/models/adapters/checkpoint_block_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/checkpoint_block_adapter.dart
@@ -6,8 +6,8 @@ class CheckPointBlockAdapter extends TypeAdapter<CheckPointBlock> {
 
   @override
   CheckPointBlock read(BinaryReader reader) {
-    final int numOfFields = reader.readByte();
-    final Map<int, dynamic> fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return CheckPointBlock(

--- a/packages/komodo_coin_updates/lib/src/models/adapters/checkpoint_block_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/checkpoint_block_adapter.dart
@@ -1,0 +1,44 @@
+part of '../checkpoint_block.dart';
+
+class CheckPointBlockAdapter extends TypeAdapter<CheckPointBlock> {
+  @override
+  final int typeId = 6;
+
+  @override
+  CheckPointBlock read(BinaryReader reader) {
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return CheckPointBlock(
+      height: fields[0] as num?,
+      time: fields[1] as num?,
+      hash: fields[2] as String?,
+      saplingTree: fields[3] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, CheckPointBlock obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.height)
+      ..writeByte(1)
+      ..write(obj.time)
+      ..writeByte(2)
+      ..write(obj.hash)
+      ..writeByte(3)
+      ..write(obj.saplingTree);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CheckPointBlockAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/packages/komodo_coin_updates/lib/src/models/adapters/coin_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/coin_adapter.dart
@@ -1,0 +1,167 @@
+part of '../coin.dart';
+
+class CoinAdapter extends TypeAdapter<Coin> {
+  @override
+  final int typeId = 0;
+
+  @override
+  Coin read(BinaryReader reader) {
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return Coin(
+      coin: fields[0] as String,
+      name: fields[1] as String?,
+      fname: fields[2] as String?,
+      rpcport: fields[3] as num?,
+      mm2: fields[4] as num?,
+      chainId: fields[5] as num?,
+      requiredConfirmations: fields[6] as num?,
+      avgBlocktime: fields[7] as num?,
+      decimals: fields[8] as num?,
+      protocol: fields[9] as Protocol?,
+      derivationPath: fields[10] as String?,
+      trezorCoin: fields[11] as String?,
+      links: fields[12] as Links?,
+      isPoS: fields[13] as num?,
+      pubtype: fields[14] as num?,
+      p2shtype: fields[15] as num?,
+      wiftype: fields[16] as num?,
+      txfee: fields[17] as num?,
+      dust: fields[18] as num?,
+      matureConfirmations: fields[19] as num?,
+      segwit: fields[20] as bool?,
+      signMessagePrefix: fields[21] as String?,
+      asset: fields[22] as String?,
+      txversion: fields[23] as num?,
+      overwintered: fields[24] as num?,
+      requiresNotarization: fields[25] as bool?,
+      walletOnly: fields[26] as bool?,
+      bech32Hrp: fields[27] as String?,
+      isTestnet: fields[28] as bool?,
+      forkId: fields[29] as String?,
+      signatureVersion: fields[30] as String?,
+      confpath: fields[31] as String?,
+      addressFormat: fields[32] as AddressFormat?,
+      aliasTicker: fields[33] as String?,
+      estimateFeeMode: fields[34] as String?,
+      orderbookTicker: fields[35] as String?,
+      taddr: fields[36] as num?,
+      forceMinRelayFee: fields[37] as bool?,
+      p2p: fields[38] as num?,
+      magic: fields[39] as String?,
+      nSPV: fields[40] as String?,
+      isPoSV: fields[41] as num?,
+      versionGroupId: fields[42] as String?,
+      consensusBranchId: fields[43] as String?,
+      estimateFeeBlocks: fields[44] as num?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Coin obj) {
+    writer
+      ..writeByte(45)
+      ..writeByte(0)
+      ..write(obj.coin)
+      ..writeByte(1)
+      ..write(obj.name)
+      ..writeByte(2)
+      ..write(obj.fname)
+      ..writeByte(3)
+      ..write(obj.rpcport)
+      ..writeByte(4)
+      ..write(obj.mm2)
+      ..writeByte(5)
+      ..write(obj.chainId)
+      ..writeByte(6)
+      ..write(obj.requiredConfirmations)
+      ..writeByte(7)
+      ..write(obj.avgBlocktime)
+      ..writeByte(8)
+      ..write(obj.decimals)
+      ..writeByte(9)
+      ..write(obj.protocol)
+      ..writeByte(10)
+      ..write(obj.derivationPath)
+      ..writeByte(11)
+      ..write(obj.trezorCoin)
+      ..writeByte(12)
+      ..write(obj.links)
+      ..writeByte(13)
+      ..write(obj.isPoS)
+      ..writeByte(14)
+      ..write(obj.pubtype)
+      ..writeByte(15)
+      ..write(obj.p2shtype)
+      ..writeByte(16)
+      ..write(obj.wiftype)
+      ..writeByte(17)
+      ..write(obj.txfee)
+      ..writeByte(18)
+      ..write(obj.dust)
+      ..writeByte(19)
+      ..write(obj.matureConfirmations)
+      ..writeByte(20)
+      ..write(obj.segwit)
+      ..writeByte(21)
+      ..write(obj.signMessagePrefix)
+      ..writeByte(22)
+      ..write(obj.asset)
+      ..writeByte(23)
+      ..write(obj.txversion)
+      ..writeByte(24)
+      ..write(obj.overwintered)
+      ..writeByte(25)
+      ..write(obj.requiresNotarization)
+      ..writeByte(26)
+      ..write(obj.walletOnly)
+      ..writeByte(27)
+      ..write(obj.bech32Hrp)
+      ..writeByte(28)
+      ..write(obj.isTestnet)
+      ..writeByte(29)
+      ..write(obj.forkId)
+      ..writeByte(30)
+      ..write(obj.signatureVersion)
+      ..writeByte(31)
+      ..write(obj.confpath)
+      ..writeByte(32)
+      ..write(obj.addressFormat)
+      ..writeByte(33)
+      ..write(obj.aliasTicker)
+      ..writeByte(34)
+      ..write(obj.estimateFeeMode)
+      ..writeByte(35)
+      ..write(obj.orderbookTicker)
+      ..writeByte(36)
+      ..write(obj.taddr)
+      ..writeByte(37)
+      ..write(obj.forceMinRelayFee)
+      ..writeByte(38)
+      ..write(obj.p2p)
+      ..writeByte(39)
+      ..write(obj.magic)
+      ..writeByte(40)
+      ..write(obj.nSPV)
+      ..writeByte(41)
+      ..write(obj.isPoSV)
+      ..writeByte(42)
+      ..write(obj.versionGroupId)
+      ..writeByte(43)
+      ..write(obj.consensusBranchId)
+      ..writeByte(44)
+      ..write(obj.estimateFeeBlocks);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CoinAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/packages/komodo_coin_updates/lib/src/models/adapters/coin_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/coin_adapter.dart
@@ -6,8 +6,8 @@ class CoinAdapter extends TypeAdapter<Coin> {
 
   @override
   Coin read(BinaryReader reader) {
-    final int numOfFields = reader.readByte();
-    final Map<int, dynamic> fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return Coin(

--- a/packages/komodo_coin_updates/lib/src/models/adapters/coin_config_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/coin_config_adapter.dart
@@ -6,8 +6,8 @@ class CoinConfigAdapter extends TypeAdapter<CoinConfig> {
 
   @override
   CoinConfig read(BinaryReader reader) {
-    final int numOfFields = reader.readByte();
-    final Map<int, dynamic> fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return CoinConfig(

--- a/packages/komodo_coin_updates/lib/src/models/adapters/coin_config_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/coin_config_adapter.dart
@@ -1,0 +1,248 @@
+part of '../coin_config.dart';
+
+class CoinConfigAdapter extends TypeAdapter<CoinConfig> {
+  @override
+  final int typeId = 7;
+
+  @override
+  CoinConfig read(BinaryReader reader) {
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return CoinConfig(
+      coin: fields[0] as String,
+      type: fields[1] as String?,
+      name: fields[2] as String?,
+      coingeckoId: fields[3] as String?,
+      livecoinwatchId: fields[4] as String?,
+      explorerUrl: fields[5] as String?,
+      explorerTxUrl: fields[6] as String?,
+      explorerAddressUrl: fields[7] as String?,
+      supported: (fields[8] as List<dynamic>?)?.cast<String>(),
+      active: fields[9] as bool?,
+      isTestnet: fields[10] as bool?,
+      currentlyEnabled: fields[11] as bool?,
+      walletOnly: fields[12] as bool?,
+      fname: fields[13] as String?,
+      rpcport: fields[14] as num?,
+      mm2: fields[15] as num?,
+      chainId: fields[16] as num?,
+      requiredConfirmations: fields[17] as num?,
+      avgBlocktime: fields[18] as num?,
+      decimals: fields[19] as num?,
+      protocol: fields[20] as Protocol?,
+      derivationPath: fields[21] as String?,
+      contractAddress: fields[22] as String?,
+      parentCoin: fields[23] as String?,
+      swapContractAddress: fields[24] as String?,
+      fallbackSwapContract: fields[25] as String?,
+      nodes: (fields[26] as List<dynamic>?)?.cast<Node>(),
+      explorerBlockUrl: fields[27] as String?,
+      tokenAddressUrl: fields[28] as String?,
+      trezorCoin: fields[29] as String?,
+      links: fields[30] as Links?,
+      pubtype: fields[31] as num?,
+      p2shtype: fields[32] as num?,
+      wiftype: fields[33] as num?,
+      txfee: fields[34] as num?,
+      dust: fields[35] as num?,
+      segwit: fields[36] as bool?,
+      electrum: (fields[37] as List<dynamic>?)?.cast<Electrum>(),
+      signMessagePrefix: fields[38] as String?,
+      lightWalletDServers: (fields[39] as List<dynamic>?)?.cast<String>(),
+      asset: fields[40] as String?,
+      txversion: fields[41] as num?,
+      overwintered: fields[42] as num?,
+      requiresNotarization: fields[43] as bool?,
+      checkpointHeight: fields[44] as num?,
+      checkpointBlocktime: fields[45] as num?,
+      binanceId: fields[46] as String?,
+      bech32Hrp: fields[47] as String?,
+      forkId: fields[48] as String?,
+      signatureVersion: fields[49] as String?,
+      confpath: fields[50] as String?,
+      matureConfirmations: fields[51] as num?,
+      bchdUrls: (fields[52] as List<dynamic>?)?.cast<String>(),
+      otherTypes: (fields[53] as List<dynamic>?)?.cast<String>(),
+      addressFormat: fields[54] as AddressFormat?,
+      allowSlpUnsafeConf: fields[55] as bool?,
+      slpPrefix: fields[56] as String?,
+      tokenId: fields[57] as String?,
+      forexId: fields[58] as String?,
+      isPoS: fields[59] as num?,
+      aliasTicker: fields[60] as String?,
+      estimateFeeMode: fields[61] as String?,
+      orderbookTicker: fields[62] as String?,
+      taddr: fields[63] as num?,
+      forceMinRelayFee: fields[64] as bool?,
+      isClaimable: fields[65] as bool?,
+      minimalClaimAmount: fields[66] as String?,
+      isPoSV: fields[67] as num?,
+      versionGroupId: fields[68] as String?,
+      consensusBranchId: fields[69] as String?,
+      estimateFeeBlocks: fields[70] as num?,
+      rpcUrls: (fields[71] as List<dynamic>?)?.cast<RpcUrl>(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, CoinConfig obj) {
+    writer
+      ..writeByte(72)
+      ..writeByte(0)
+      ..write(obj.coin)
+      ..writeByte(1)
+      ..write(obj.type)
+      ..writeByte(2)
+      ..write(obj.name)
+      ..writeByte(3)
+      ..write(obj.coingeckoId)
+      ..writeByte(4)
+      ..write(obj.livecoinwatchId)
+      ..writeByte(5)
+      ..write(obj.explorerUrl)
+      ..writeByte(6)
+      ..write(obj.explorerTxUrl)
+      ..writeByte(7)
+      ..write(obj.explorerAddressUrl)
+      ..writeByte(8)
+      ..write(obj.supported)
+      ..writeByte(9)
+      ..write(obj.active)
+      ..writeByte(10)
+      ..write(obj.isTestnet)
+      ..writeByte(11)
+      ..write(obj.currentlyEnabled)
+      ..writeByte(12)
+      ..write(obj.walletOnly)
+      ..writeByte(13)
+      ..write(obj.fname)
+      ..writeByte(14)
+      ..write(obj.rpcport)
+      ..writeByte(15)
+      ..write(obj.mm2)
+      ..writeByte(16)
+      ..write(obj.chainId)
+      ..writeByte(17)
+      ..write(obj.requiredConfirmations)
+      ..writeByte(18)
+      ..write(obj.avgBlocktime)
+      ..writeByte(19)
+      ..write(obj.decimals)
+      ..writeByte(20)
+      ..write(obj.protocol)
+      ..writeByte(21)
+      ..write(obj.derivationPath)
+      ..writeByte(22)
+      ..write(obj.contractAddress)
+      ..writeByte(23)
+      ..write(obj.parentCoin)
+      ..writeByte(24)
+      ..write(obj.swapContractAddress)
+      ..writeByte(25)
+      ..write(obj.fallbackSwapContract)
+      ..writeByte(26)
+      ..write(obj.nodes)
+      ..writeByte(27)
+      ..write(obj.explorerBlockUrl)
+      ..writeByte(28)
+      ..write(obj.tokenAddressUrl)
+      ..writeByte(29)
+      ..write(obj.trezorCoin)
+      ..writeByte(30)
+      ..write(obj.links)
+      ..writeByte(31)
+      ..write(obj.pubtype)
+      ..writeByte(32)
+      ..write(obj.p2shtype)
+      ..writeByte(33)
+      ..write(obj.wiftype)
+      ..writeByte(34)
+      ..write(obj.txfee)
+      ..writeByte(35)
+      ..write(obj.dust)
+      ..writeByte(36)
+      ..write(obj.segwit)
+      ..writeByte(37)
+      ..write(obj.electrum)
+      ..writeByte(38)
+      ..write(obj.signMessagePrefix)
+      ..writeByte(39)
+      ..write(obj.lightWalletDServers)
+      ..writeByte(40)
+      ..write(obj.asset)
+      ..writeByte(41)
+      ..write(obj.txversion)
+      ..writeByte(42)
+      ..write(obj.overwintered)
+      ..writeByte(43)
+      ..write(obj.requiresNotarization)
+      ..writeByte(44)
+      ..write(obj.checkpointHeight)
+      ..writeByte(45)
+      ..write(obj.checkpointBlocktime)
+      ..writeByte(46)
+      ..write(obj.binanceId)
+      ..writeByte(47)
+      ..write(obj.bech32Hrp)
+      ..writeByte(48)
+      ..write(obj.forkId)
+      ..writeByte(49)
+      ..write(obj.signatureVersion)
+      ..writeByte(50)
+      ..write(obj.confpath)
+      ..writeByte(51)
+      ..write(obj.matureConfirmations)
+      ..writeByte(52)
+      ..write(obj.bchdUrls)
+      ..writeByte(53)
+      ..write(obj.otherTypes)
+      ..writeByte(54)
+      ..write(obj.addressFormat)
+      ..writeByte(55)
+      ..write(obj.allowSlpUnsafeConf)
+      ..writeByte(56)
+      ..write(obj.slpPrefix)
+      ..writeByte(57)
+      ..write(obj.tokenId)
+      ..writeByte(58)
+      ..write(obj.forexId)
+      ..writeByte(59)
+      ..write(obj.isPoS)
+      ..writeByte(60)
+      ..write(obj.aliasTicker)
+      ..writeByte(61)
+      ..write(obj.estimateFeeMode)
+      ..writeByte(62)
+      ..write(obj.orderbookTicker)
+      ..writeByte(63)
+      ..write(obj.taddr)
+      ..writeByte(64)
+      ..write(obj.forceMinRelayFee)
+      ..writeByte(65)
+      ..write(obj.isClaimable)
+      ..writeByte(66)
+      ..write(obj.minimalClaimAmount)
+      ..writeByte(67)
+      ..write(obj.isPoSV)
+      ..writeByte(68)
+      ..write(obj.versionGroupId)
+      ..writeByte(69)
+      ..write(obj.consensusBranchId)
+      ..writeByte(70)
+      ..write(obj.estimateFeeBlocks)
+      ..writeByte(71)
+      ..write(obj.rpcUrls);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CoinConfigAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/packages/komodo_coin_updates/lib/src/models/adapters/coin_info_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/coin_info_adapter.dart
@@ -1,0 +1,38 @@
+part of '../coin_info.dart';
+
+class CoinInfoAdapter extends TypeAdapter<CoinInfo> {
+  @override
+  final int typeId = 13;
+
+  @override
+  CoinInfo read(BinaryReader reader) {
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return CoinInfo(
+      coin: fields[0] as Coin,
+      coinConfig: fields[1] as CoinConfig?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, CoinInfo obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.coin)
+      ..writeByte(1)
+      ..write(obj.coinConfig);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NodeAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/packages/komodo_coin_updates/lib/src/models/adapters/coin_info_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/coin_info_adapter.dart
@@ -6,8 +6,8 @@ class CoinInfoAdapter extends TypeAdapter<CoinInfo> {
 
   @override
   CoinInfo read(BinaryReader reader) {
-    final int numOfFields = reader.readByte();
-    final Map<int, dynamic> fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return CoinInfo(

--- a/packages/komodo_coin_updates/lib/src/models/adapters/consensus_params_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/consensus_params_adapter.dart
@@ -6,8 +6,8 @@ class ConsensusParamsAdapter extends TypeAdapter<ConsensusParams> {
 
   @override
   ConsensusParams read(BinaryReader reader) {
-    final int numOfFields = reader.readByte();
-    final Map<int, dynamic> fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return ConsensusParams(

--- a/packages/komodo_coin_updates/lib/src/models/adapters/consensus_params_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/consensus_params_adapter.dart
@@ -1,0 +1,65 @@
+part of '../consensus_params.dart';
+
+class ConsensusParamsAdapter extends TypeAdapter<ConsensusParams> {
+  @override
+  final int typeId = 5;
+
+  @override
+  ConsensusParams read(BinaryReader reader) {
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ConsensusParams(
+      overwinterActivationHeight: fields[0] as num?,
+      saplingActivationHeight: fields[1] as num?,
+      blossomActivationHeight: fields[2] as num?,
+      heartwoodActivationHeight: fields[3] as num?,
+      canopyActivationHeight: fields[4] as num?,
+      coinType: fields[5] as num?,
+      hrpSaplingExtendedSpendingKey: fields[6] as String?,
+      hrpSaplingExtendedFullViewingKey: fields[7] as String?,
+      hrpSaplingPaymentAddress: fields[8] as String?,
+      b58PubkeyAddressPrefix: (fields[9] as List<dynamic>?)?.cast<num>(),
+      b58ScriptAddressPrefix: (fields[10] as List<dynamic>?)?.cast<num>(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ConsensusParams obj) {
+    writer
+      ..writeByte(11)
+      ..writeByte(0)
+      ..write(obj.overwinterActivationHeight)
+      ..writeByte(1)
+      ..write(obj.saplingActivationHeight)
+      ..writeByte(2)
+      ..write(obj.blossomActivationHeight)
+      ..writeByte(3)
+      ..write(obj.heartwoodActivationHeight)
+      ..writeByte(4)
+      ..write(obj.canopyActivationHeight)
+      ..writeByte(5)
+      ..write(obj.coinType)
+      ..writeByte(6)
+      ..write(obj.hrpSaplingExtendedSpendingKey)
+      ..writeByte(7)
+      ..write(obj.hrpSaplingExtendedFullViewingKey)
+      ..writeByte(8)
+      ..write(obj.hrpSaplingPaymentAddress)
+      ..writeByte(9)
+      ..write(obj.b58PubkeyAddressPrefix)
+      ..writeByte(10)
+      ..write(obj.b58ScriptAddressPrefix);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConsensusParamsAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/packages/komodo_coin_updates/lib/src/models/adapters/contact_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/contact_adapter.dart
@@ -6,14 +6,11 @@ class ContactAdapter extends TypeAdapter<Contact> {
 
   @override
   Contact read(BinaryReader reader) {
-    final int numOfFields = reader.readByte();
-    final Map<int, dynamic> fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
-    return Contact(
-      email: fields[0] as String?,
-      github: fields[1] as String?,
-    );
+    return Contact(email: fields[0] as String?, github: fields[1] as String?);
   }
 
   @override

--- a/packages/komodo_coin_updates/lib/src/models/adapters/contact_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/contact_adapter.dart
@@ -1,0 +1,38 @@
+part of '../contact.dart';
+
+class ContactAdapter extends TypeAdapter<Contact> {
+  @override
+  final int typeId = 10;
+
+  @override
+  Contact read(BinaryReader reader) {
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return Contact(
+      email: fields[0] as String?,
+      github: fields[1] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Contact obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.email)
+      ..writeByte(1)
+      ..write(obj.github);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ContactAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/packages/komodo_coin_updates/lib/src/models/adapters/electrum_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/electrum_adapter.dart
@@ -6,8 +6,8 @@ class ElectrumAdapter extends TypeAdapter<Electrum> {
 
   @override
   Electrum read(BinaryReader reader) {
-    final int numOfFields = reader.readByte();
-    final Map<int, dynamic> fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return Electrum(

--- a/packages/komodo_coin_updates/lib/src/models/adapters/electrum_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/electrum_adapter.dart
@@ -1,0 +1,41 @@
+part of '../electrum.dart';
+
+class ElectrumAdapter extends TypeAdapter<Electrum> {
+  @override
+  final int typeId = 8;
+
+  @override
+  Electrum read(BinaryReader reader) {
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return Electrum(
+      url: fields[0] as String?,
+      protocol: fields[1] as String?,
+      contact: (fields[2] as List<dynamic>?)?.cast<Contact>(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Electrum obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.url)
+      ..writeByte(1)
+      ..write(obj.protocol)
+      ..writeByte(2)
+      ..write(obj.contact);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ElectrumAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/packages/komodo_coin_updates/lib/src/models/adapters/links_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/links_adapter.dart
@@ -6,14 +6,11 @@ class LinksAdapter extends TypeAdapter<Links> {
 
   @override
   Links read(BinaryReader reader) {
-    final int numOfFields = reader.readByte();
-    final Map<int, dynamic> fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
-    return Links(
-      github: fields[0] as String?,
-      homepage: fields[1] as String?,
-    );
+    return Links(github: fields[0] as String?, homepage: fields[1] as String?);
   }
 
   @override

--- a/packages/komodo_coin_updates/lib/src/models/adapters/links_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/links_adapter.dart
@@ -1,0 +1,38 @@
+part of '../links.dart';
+
+class LinksAdapter extends TypeAdapter<Links> {
+  @override
+  final int typeId = 4;
+
+  @override
+  Links read(BinaryReader reader) {
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return Links(
+      github: fields[0] as String?,
+      homepage: fields[1] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Links obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.github)
+      ..writeByte(1)
+      ..write(obj.homepage);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is LinksAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/packages/komodo_coin_updates/lib/src/models/adapters/node_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/node_adapter.dart
@@ -1,0 +1,38 @@
+part of '../node.dart';
+
+class NodeAdapter extends TypeAdapter<Node> {
+  @override
+  final int typeId = 9;
+
+  @override
+  Node read(BinaryReader reader) {
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return Node(
+      url: fields[0] as String?,
+      guiAuth: fields[1] as bool?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Node obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.url)
+      ..writeByte(1)
+      ..write(obj.guiAuth);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NodeAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/packages/komodo_coin_updates/lib/src/models/adapters/node_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/node_adapter.dart
@@ -6,14 +6,11 @@ class NodeAdapter extends TypeAdapter<Node> {
 
   @override
   Node read(BinaryReader reader) {
-    final int numOfFields = reader.readByte();
-    final Map<int, dynamic> fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
-    return Node(
-      url: fields[0] as String?,
-      guiAuth: fields[1] as bool?,
-    );
+    return Node(url: fields[0] as String?, guiAuth: fields[1] as bool?);
   }
 
   @override

--- a/packages/komodo_coin_updates/lib/src/models/adapters/protocol_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/protocol_adapter.dart
@@ -6,8 +6,8 @@ class ProtocolAdapter extends TypeAdapter<Protocol> {
 
   @override
   Protocol read(BinaryReader reader) {
-    final int numOfFields = reader.readByte();
-    final Map<int, dynamic> fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return Protocol(

--- a/packages/komodo_coin_updates/lib/src/models/adapters/protocol_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/protocol_adapter.dart
@@ -1,0 +1,41 @@
+part of '../protocol.dart';
+
+class ProtocolAdapter extends TypeAdapter<Protocol> {
+  @override
+  final int typeId = 1;
+
+  @override
+  Protocol read(BinaryReader reader) {
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return Protocol(
+      type: fields[0] as String?,
+      protocolData: fields[1] as ProtocolData?,
+      bip44: fields[2] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Protocol obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.type)
+      ..writeByte(1)
+      ..write(obj.protocolData)
+      ..writeByte(2)
+      ..write(obj.bip44);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ProtocolAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/packages/komodo_coin_updates/lib/src/models/adapters/protocol_data_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/protocol_data_adapter.dart
@@ -6,8 +6,8 @@ class ProtocolDataAdapter extends TypeAdapter<ProtocolData> {
 
   @override
   ProtocolData read(BinaryReader reader) {
-    final int numOfFields = reader.readByte();
-    final Map<int, dynamic> fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return ProtocolData(

--- a/packages/komodo_coin_updates/lib/src/models/adapters/protocol_data_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/protocol_data_adapter.dart
@@ -1,0 +1,68 @@
+part of '../protocol_data.dart';
+
+class ProtocolDataAdapter extends TypeAdapter<ProtocolData> {
+  @override
+  final int typeId = 2;
+
+  @override
+  ProtocolData read(BinaryReader reader) {
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return ProtocolData(
+      platform: fields[0] as String?,
+      contractAddress: fields[1] as String?,
+      consensusParams: fields[2] as ConsensusParams?,
+      checkPointBlock: fields[3] as CheckPointBlock?,
+      slpPrefix: fields[4] as String?,
+      decimals: fields[5] as num?,
+      tokenId: fields[6] as String?,
+      requiredConfirmations: fields[7] as num?,
+      denom: fields[8] as String?,
+      accountPrefix: fields[9] as String?,
+      chainId: fields[10] as String?,
+      gasPrice: fields[11] as num?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, ProtocolData obj) {
+    writer
+      ..writeByte(12)
+      ..writeByte(0)
+      ..write(obj.platform)
+      ..writeByte(1)
+      ..write(obj.contractAddress)
+      ..writeByte(2)
+      ..write(obj.consensusParams ?? const ConsensusParams())
+      ..writeByte(3)
+      ..write(obj.checkPointBlock ?? const CheckPointBlock())
+      ..writeByte(4)
+      ..write(obj.slpPrefix)
+      ..writeByte(5)
+      ..write(obj.decimals)
+      ..writeByte(6)
+      ..write(obj.tokenId)
+      ..writeByte(7)
+      ..write(obj.requiredConfirmations)
+      ..writeByte(8)
+      ..write(obj.denom)
+      ..writeByte(9)
+      ..write(obj.accountPrefix)
+      ..writeByte(10)
+      ..write(obj.chainId)
+      ..writeByte(11)
+      ..write(obj.gasPrice);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ProtocolDataAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/packages/komodo_coin_updates/lib/src/models/adapters/rpc_url_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/rpc_url_adapter.dart
@@ -6,13 +6,11 @@ class RpcUrlAdapter extends TypeAdapter<RpcUrl> {
 
   @override
   RpcUrl read(BinaryReader reader) {
-    final int numOfFields = reader.readByte();
-    final Map<int, dynamic> fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
-    return RpcUrl(
-      url: fields[0] as String?,
-    );
+    return RpcUrl(url: fields[0] as String?);
   }
 
   @override

--- a/packages/komodo_coin_updates/lib/src/models/adapters/rpc_url_adapter.dart
+++ b/packages/komodo_coin_updates/lib/src/models/adapters/rpc_url_adapter.dart
@@ -1,0 +1,35 @@
+part of '../rpc_url.dart';
+
+class RpcUrlAdapter extends TypeAdapter<RpcUrl> {
+  @override
+  final int typeId = 11;
+
+  @override
+  RpcUrl read(BinaryReader reader) {
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return RpcUrl(
+      url: fields[0] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, RpcUrl obj) {
+    writer
+      ..writeByte(1)
+      ..writeByte(0)
+      ..write(obj.url);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RpcUrlAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/packages/komodo_coin_updates/lib/src/models/address_format.dart
+++ b/packages/komodo_coin_updates/lib/src/models/address_format.dart
@@ -4,10 +4,7 @@ import 'package:hive/hive.dart';
 part 'adapters/address_format_adapter.dart';
 
 class AddressFormat extends Equatable {
-  const AddressFormat({
-    this.format,
-    this.network,
-  });
+  const AddressFormat({this.format, this.network});
 
   factory AddressFormat.fromJson(Map<String, dynamic> json) {
     return AddressFormat(
@@ -20,10 +17,7 @@ class AddressFormat extends Equatable {
   final String? network;
 
   Map<String, dynamic> toJson() {
-    return <String, dynamic>{
-      'format': format,
-      'network': network,
-    };
+    return <String, dynamic>{'format': format, 'network': network};
   }
 
   @override

--- a/packages/komodo_coin_updates/lib/src/models/address_format.dart
+++ b/packages/komodo_coin_updates/lib/src/models/address_format.dart
@@ -1,0 +1,31 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+
+part 'adapters/address_format_adapter.dart';
+
+class AddressFormat extends Equatable {
+  const AddressFormat({
+    this.format,
+    this.network,
+  });
+
+  factory AddressFormat.fromJson(Map<String, dynamic> json) {
+    return AddressFormat(
+      format: json['format'] as String?,
+      network: json['network'] as String?,
+    );
+  }
+
+  final String? format;
+  final String? network;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'format': format,
+      'network': network,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[format, network];
+}

--- a/packages/komodo_coin_updates/lib/src/models/checkpoint_block.dart
+++ b/packages/komodo_coin_updates/lib/src/models/checkpoint_block.dart
@@ -1,0 +1,39 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+
+part 'adapters/checkpoint_block_adapter.dart';
+
+class CheckPointBlock extends Equatable {
+  const CheckPointBlock({
+    this.height,
+    this.time,
+    this.hash,
+    this.saplingTree,
+  });
+
+  factory CheckPointBlock.fromJson(Map<String, dynamic> json) {
+    return CheckPointBlock(
+      height: json['height'] as num?,
+      time: json['time'] as num?,
+      hash: json['hash'] as String?,
+      saplingTree: json['saplingTree'] as String?,
+    );
+  }
+
+  final num? height;
+  final num? time;
+  final String? hash;
+  final String? saplingTree;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'height': height,
+      'time': time,
+      'hash': hash,
+      'saplingTree': saplingTree,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[height, time, hash, saplingTree];
+}

--- a/packages/komodo_coin_updates/lib/src/models/checkpoint_block.dart
+++ b/packages/komodo_coin_updates/lib/src/models/checkpoint_block.dart
@@ -4,12 +4,7 @@ import 'package:hive/hive.dart';
 part 'adapters/checkpoint_block_adapter.dart';
 
 class CheckPointBlock extends Equatable {
-  const CheckPointBlock({
-    this.height,
-    this.time,
-    this.hash,
-    this.saplingTree,
-  });
+  const CheckPointBlock({this.height, this.time, this.hash, this.saplingTree});
 
   factory CheckPointBlock.fromJson(Map<String, dynamic> json) {
     return CheckPointBlock(

--- a/packages/komodo_coin_updates/lib/src/models/coin.dart
+++ b/packages/komodo_coin_updates/lib/src/models/coin.dart
@@ -1,6 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:hive/hive.dart';
-import 'package:komodo_persistence_layer/komodo_persistence_layer.dart';
+import 'package:komodo_coin_updates/src/persistence/persistence_provider.dart';
 
 import 'address_format.dart';
 import 'links.dart';

--- a/packages/komodo_coin_updates/lib/src/models/coin.dart
+++ b/packages/komodo_coin_updates/lib/src/models/coin.dart
@@ -1,0 +1,219 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+import 'package:komodo_persistence_layer/komodo_persistence_layer.dart';
+
+import 'address_format.dart';
+import 'links.dart';
+import 'protocol.dart';
+
+part 'adapters/coin_adapter.dart';
+
+class Coin extends Equatable implements ObjectWithPrimaryKey<String> {
+  const Coin({
+    required this.coin,
+    this.name,
+    this.fname,
+    this.rpcport,
+    this.mm2,
+    this.chainId,
+    this.requiredConfirmations,
+    this.avgBlocktime,
+    this.decimals,
+    this.protocol,
+    this.derivationPath,
+    this.trezorCoin,
+    this.links,
+    this.isPoS,
+    this.pubtype,
+    this.p2shtype,
+    this.wiftype,
+    this.txfee,
+    this.dust,
+    this.matureConfirmations,
+    this.segwit,
+    this.signMessagePrefix,
+    this.asset,
+    this.txversion,
+    this.overwintered,
+    this.requiresNotarization,
+    this.walletOnly,
+    this.bech32Hrp,
+    this.isTestnet,
+    this.forkId,
+    this.signatureVersion,
+    this.confpath,
+    this.addressFormat,
+    this.aliasTicker,
+    this.estimateFeeMode,
+    this.orderbookTicker,
+    this.taddr,
+    this.forceMinRelayFee,
+    this.p2p,
+    this.magic,
+    this.nSPV,
+    this.isPoSV,
+    this.versionGroupId,
+    this.consensusBranchId,
+    this.estimateFeeBlocks,
+  });
+
+  factory Coin.fromJson(Map<String, dynamic> json) {
+    return Coin(
+      coin: json['coin'] as String,
+      name: json['name'] as String?,
+      fname: json['fname'] as String?,
+      rpcport: json['rpcport'] as num?,
+      mm2: json['mm2'] as num?,
+      chainId: json['chain_id'] as num?,
+      requiredConfirmations: json['required_confirmations'] as num?,
+      avgBlocktime: json['avg_blocktime'] as num?,
+      decimals: json['decimals'] as num?,
+      protocol: json['protocol'] != null
+          ? Protocol.fromJson(json['protocol'] as Map<String, dynamic>)
+          : null,
+      derivationPath: json['derivation_path'] as String?,
+      trezorCoin: json['trezor_coin'] as String?,
+      links: json['links'] != null
+          ? Links.fromJson(json['links'] as Map<String, dynamic>)
+          : null,
+      isPoS: json['isPoS'] as num?,
+      pubtype: json['pubtype'] as num?,
+      p2shtype: json['p2shtype'] as num?,
+      wiftype: json['wiftype'] as num?,
+      txfee: json['txfee'] as num?,
+      dust: json['dust'] as num?,
+      matureConfirmations: json['mature_confirmations'] as num?,
+      segwit: json['segwit'] as bool?,
+      signMessagePrefix: json['sign_message_prefix'] as String?,
+      asset: json['asset'] as String?,
+      txversion: json['txversion'] as num?,
+      overwintered: json['overwintered'] as num?,
+      requiresNotarization: json['requires_notarization'] as bool?,
+      walletOnly: json['wallet_only'] as bool?,
+      bech32Hrp: json['bech32_hrp'] as String?,
+      isTestnet: json['is_testnet'] as bool?,
+      forkId: json['fork_id'] as String?,
+      signatureVersion: json['signature_version'] as String?,
+      confpath: json['confpath'] as String?,
+      addressFormat: json['address_format'] != null
+          ? AddressFormat.fromJson(
+              json['address_format'] as Map<String, dynamic>,
+            )
+          : null,
+      aliasTicker: json['alias_ticker'] as String?,
+      estimateFeeMode: json['estimate_fee_mode'] as String?,
+      orderbookTicker: json['orderbook_ticker'] as String?,
+      taddr: json['taddr'] as num?,
+      forceMinRelayFee: json['force_min_relay_fee'] as bool?,
+      p2p: json['p2p'] as num?,
+      magic: json['magic'] as String?,
+      nSPV: json['nSPV'] as String?,
+      isPoSV: json['isPoSV'] as num?,
+      versionGroupId: json['version_group_id'] as String?,
+      consensusBranchId: json['consensus_branch_id'] as String?,
+      estimateFeeBlocks: json['estimate_fee_blocks'] as num?,
+    );
+  }
+
+  final String coin;
+  final String? name;
+  final String? fname;
+  final num? rpcport;
+  final num? mm2;
+  final num? chainId;
+  final num? requiredConfirmations;
+  final num? avgBlocktime;
+  final num? decimals;
+  final Protocol? protocol;
+  final String? derivationPath;
+  final String? trezorCoin;
+  final Links? links;
+  final num? isPoS;
+  final num? pubtype;
+  final num? p2shtype;
+  final num? wiftype;
+  final num? txfee;
+  final num? dust;
+  final num? matureConfirmations;
+  final bool? segwit;
+  final String? signMessagePrefix;
+  final String? asset;
+  final num? txversion;
+  final num? overwintered;
+  final bool? requiresNotarization;
+  final bool? walletOnly;
+  final String? bech32Hrp;
+  final bool? isTestnet;
+  final String? forkId;
+  final String? signatureVersion;
+  final String? confpath;
+  final AddressFormat? addressFormat;
+  final String? aliasTicker;
+  final String? estimateFeeMode;
+  final String? orderbookTicker;
+  final num? taddr;
+  final bool? forceMinRelayFee;
+  final num? p2p;
+  final String? magic;
+  final String? nSPV;
+  final num? isPoSV;
+  final String? versionGroupId;
+  final String? consensusBranchId;
+  final num? estimateFeeBlocks;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'coin': coin,
+      'name': name,
+      'fname': fname,
+      'rpcport': rpcport,
+      'mm2': mm2,
+      'chain_id': chainId,
+      'required_confirmations': requiredConfirmations,
+      'avg_blocktime': avgBlocktime,
+      'decimals': decimals,
+      'protocol': protocol?.toJson(),
+      'derivation_path': derivationPath,
+      'trezor_coin': trezorCoin,
+      'links': links?.toJson(),
+      'isPoS': isPoS,
+      'pubtype': pubtype,
+      'p2shtype': p2shtype,
+      'wiftype': wiftype,
+      'txfee': txfee,
+      'dust': dust,
+      'mature_confirmations': matureConfirmations,
+      'segwit': segwit,
+      'sign_message_prefix': signMessagePrefix,
+      'asset': asset,
+      'txversion': txversion,
+      'overwintered': overwintered,
+      'requires_notarization': requiresNotarization,
+      'wallet_only': walletOnly,
+      'bech32_hrp': bech32Hrp,
+      'is_testnet': isTestnet,
+      'fork_id': forkId,
+      'signature_version': signatureVersion,
+      'confpath': confpath,
+      'address_format': addressFormat?.toJson(),
+      'alias_ticker': aliasTicker,
+      'estimate_fee_mode': estimateFeeMode,
+      'orderbook_ticker': orderbookTicker,
+      'taddr': taddr,
+      'force_min_relay_fee': forceMinRelayFee,
+      'p2p': p2p,
+      'magic': magic,
+      'nSPV': nSPV,
+      'isPoSV': isPoSV,
+      'version_group_id': versionGroupId,
+      'consensus_branch_id': consensusBranchId,
+      'estimate_fee_blocks': estimateFeeBlocks,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[coin];
+
+  @override
+  String get primaryKey => coin;
+}

--- a/packages/komodo_coin_updates/lib/src/models/coin.dart
+++ b/packages/komodo_coin_updates/lib/src/models/coin.dart
@@ -1,10 +1,9 @@
 import 'package:equatable/equatable.dart';
 import 'package:hive/hive.dart';
+import 'package:komodo_coin_updates/src/models/address_format.dart';
+import 'package:komodo_coin_updates/src/models/links.dart';
+import 'package:komodo_coin_updates/src/models/protocol.dart';
 import 'package:komodo_coin_updates/src/persistence/persistence_provider.dart';
-
-import 'address_format.dart';
-import 'links.dart';
-import 'protocol.dart';
 
 part 'adapters/coin_adapter.dart';
 
@@ -68,14 +67,16 @@ class Coin extends Equatable implements ObjectWithPrimaryKey<String> {
       requiredConfirmations: json['required_confirmations'] as num?,
       avgBlocktime: json['avg_blocktime'] as num?,
       decimals: json['decimals'] as num?,
-      protocol: json['protocol'] != null
-          ? Protocol.fromJson(json['protocol'] as Map<String, dynamic>)
-          : null,
+      protocol:
+          json['protocol'] != null
+              ? Protocol.fromJson(json['protocol'] as Map<String, dynamic>)
+              : null,
       derivationPath: json['derivation_path'] as String?,
       trezorCoin: json['trezor_coin'] as String?,
-      links: json['links'] != null
-          ? Links.fromJson(json['links'] as Map<String, dynamic>)
-          : null,
+      links:
+          json['links'] != null
+              ? Links.fromJson(json['links'] as Map<String, dynamic>)
+              : null,
       isPoS: json['isPoS'] as num?,
       pubtype: json['pubtype'] as num?,
       p2shtype: json['p2shtype'] as num?,
@@ -95,11 +96,12 @@ class Coin extends Equatable implements ObjectWithPrimaryKey<String> {
       forkId: json['fork_id'] as String?,
       signatureVersion: json['signature_version'] as String?,
       confpath: json['confpath'] as String?,
-      addressFormat: json['address_format'] != null
-          ? AddressFormat.fromJson(
-              json['address_format'] as Map<String, dynamic>,
-            )
-          : null,
+      addressFormat:
+          json['address_format'] != null
+              ? AddressFormat.fromJson(
+                json['address_format'] as Map<String, dynamic>,
+              )
+              : null,
       aliasTicker: json['alias_ticker'] as String?,
       estimateFeeMode: json['estimate_fee_mode'] as String?,
       orderbookTicker: json['orderbook_ticker'] as String?,

--- a/packages/komodo_coin_updates/lib/src/models/coin_config.dart
+++ b/packages/komodo_coin_updates/lib/src/models/coin_config.dart
@@ -1,6 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:hive/hive.dart';
-import 'package:komodo_persistence_layer/komodo_persistence_layer.dart';
+import 'package:komodo_coin_updates/src/persistence/persistence_provider.dart';
 
 import 'address_format.dart';
 import 'electrum.dart';

--- a/packages/komodo_coin_updates/lib/src/models/coin_config.dart
+++ b/packages/komodo_coin_updates/lib/src/models/coin_config.dart
@@ -1,0 +1,417 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+import 'package:komodo_persistence_layer/komodo_persistence_layer.dart';
+
+import 'address_format.dart';
+import 'electrum.dart';
+import 'links.dart';
+import 'node.dart';
+import 'protocol.dart';
+import 'rpc_url.dart';
+
+part 'adapters/coin_config_adapter.dart';
+
+class CoinConfig extends Equatable implements ObjectWithPrimaryKey<String> {
+  const CoinConfig({
+    required this.coin,
+    this.type,
+    this.name,
+    this.coingeckoId,
+    this.livecoinwatchId,
+    this.explorerUrl,
+    this.explorerTxUrl,
+    this.explorerAddressUrl,
+    this.supported,
+    this.active,
+    this.isTestnet,
+    this.currentlyEnabled,
+    this.walletOnly,
+    this.fname,
+    this.rpcport,
+    this.mm2,
+    this.chainId,
+    this.requiredConfirmations,
+    this.avgBlocktime,
+    this.decimals,
+    this.protocol,
+    this.derivationPath,
+    this.contractAddress,
+    this.parentCoin,
+    this.swapContractAddress,
+    this.fallbackSwapContract,
+    this.nodes,
+    this.explorerBlockUrl,
+    this.tokenAddressUrl,
+    this.trezorCoin,
+    this.links,
+    this.pubtype,
+    this.p2shtype,
+    this.wiftype,
+    this.txfee,
+    this.dust,
+    this.segwit,
+    this.electrum,
+    this.signMessagePrefix,
+    this.lightWalletDServers,
+    this.asset,
+    this.txversion,
+    this.overwintered,
+    this.requiresNotarization,
+    this.checkpointHeight,
+    this.checkpointBlocktime,
+    this.binanceId,
+    this.bech32Hrp,
+    this.forkId,
+    this.signatureVersion,
+    this.confpath,
+    this.matureConfirmations,
+    this.bchdUrls,
+    this.otherTypes,
+    this.addressFormat,
+    this.allowSlpUnsafeConf,
+    this.slpPrefix,
+    this.tokenId,
+    this.forexId,
+    this.isPoS,
+    this.aliasTicker,
+    this.estimateFeeMode,
+    this.orderbookTicker,
+    this.taddr,
+    this.forceMinRelayFee,
+    this.isClaimable,
+    this.minimalClaimAmount,
+    this.isPoSV,
+    this.versionGroupId,
+    this.consensusBranchId,
+    this.estimateFeeBlocks,
+    this.rpcUrls,
+  });
+
+  factory CoinConfig.fromJson(Map<String, dynamic> json) {
+    return CoinConfig(
+      coin: json['coin'] as String,
+      type: json['type'] as String?,
+      name: json['name'] as String?,
+      coingeckoId: json['coingecko_id'] as String?,
+      livecoinwatchId: json['livecoinwatch_id'] as String?,
+      explorerUrl: json['explorer_url'] as String?,
+      explorerTxUrl: json['explorer_tx_url'] as String?,
+      explorerAddressUrl: json['explorer_address_url'] as String?,
+      supported: (json['supported'] as List<dynamic>?)
+          ?.map((dynamic e) => e as String)
+          .toList(),
+      active: json['active'] as bool?,
+      isTestnet: json['is_testnet'] as bool?,
+      currentlyEnabled: json['currently_enabled'] as bool?,
+      walletOnly: json['wallet_only'] as bool?,
+      fname: json['fname'] as String?,
+      rpcport: json['rpcport'] as num?,
+      mm2: json['mm2'] as num?,
+      chainId: json['chain_id'] as num?,
+      requiredConfirmations: json['required_confirmations'] as num?,
+      avgBlocktime: json['avg_blocktime'] as num?,
+      decimals: json['decimals'] as num?,
+      protocol: json['protocol'] == null
+          ? null
+          : Protocol.fromJson(json['protocol'] as Map<String, dynamic>),
+      derivationPath: json['derivation_path'] as String?,
+      contractAddress: json['contractAddress'] as String?,
+      parentCoin: json['parent_coin'] as String?,
+      swapContractAddress: json['swap_contract_address'] as String?,
+      fallbackSwapContract: json['fallback_swap_contract'] as String?,
+      nodes: (json['nodes'] as List<dynamic>?)
+          ?.map((dynamic e) => Node.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      explorerBlockUrl: json['explorer_block_url'] as String?,
+      tokenAddressUrl: json['token_address_url'] as String?,
+      trezorCoin: json['trezor_coin'] as String?,
+      links: json['links'] == null
+          ? null
+          : Links.fromJson(json['links'] as Map<String, dynamic>),
+      pubtype: json['pubtype'] as num?,
+      p2shtype: json['p2shtype'] as num?,
+      wiftype: json['wiftype'] as num?,
+      txfee: json['txfee'] as num?,
+      dust: json['dust'] as num?,
+      segwit: json['segwit'] as bool?,
+      electrum: (json['electrum'] as List<dynamic>?)
+          ?.map((dynamic e) => Electrum.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      signMessagePrefix: json['sign_message_refix'] as String?,
+      lightWalletDServers: (json['light_wallet_d_servers'] as List<dynamic>?)
+          ?.map((dynamic e) => e as String)
+          .toList(),
+      asset: json['asset'] as String?,
+      txversion: json['txversion'] as num?,
+      overwintered: json['overwintered'] as num?,
+      requiresNotarization: json['requires_notarization'] as bool?,
+      checkpointHeight: json['checkpoint_height'] as num?,
+      checkpointBlocktime: json['checkpoint_blocktime'] as num?,
+      binanceId: json['binance_id'] as String?,
+      bech32Hrp: json['bech32_hrp'] as String?,
+      forkId: json['forkId'] as String?,
+      signatureVersion: json['signature_version'] as String?,
+      confpath: json['confpath'] as String?,
+      matureConfirmations: json['mature_confirmations'] as num?,
+      bchdUrls: (json['bchd_urls'] as List<dynamic>?)
+          ?.map((dynamic e) => e as String)
+          .toList(),
+      otherTypes: (json['other_types'] as List<dynamic>?)
+          ?.map((dynamic e) => e as String)
+          .toList(),
+      addressFormat: json['address_format'] == null
+          ? null
+          : AddressFormat.fromJson(
+              json['address_format'] as Map<String, dynamic>,
+            ),
+      allowSlpUnsafeConf: json['allow_slp_unsafe_conf'] as bool?,
+      slpPrefix: json['slp_prefix'] as String?,
+      tokenId: json['token_id'] as String?,
+      forexId: json['forex_id'] as String?,
+      isPoS: json['isPoS'] as num?,
+      aliasTicker: json['alias_ticker'] as String?,
+      estimateFeeMode: json['estimate_fee_mode'] as String?,
+      orderbookTicker: json['orderbook_ticker'] as String?,
+      taddr: json['taddr'] as num?,
+      forceMinRelayFee: json['force_min_relay_fee'] as bool?,
+      isClaimable: json['is_claimable'] as bool?,
+      minimalClaimAmount: json['minimal_claim_amount'] as String?,
+      isPoSV: json['isPoSV'] as num?,
+      versionGroupId: json['version_group_id'] as String?,
+      consensusBranchId: json['consensus_branch_id'] as String?,
+      estimateFeeBlocks: json['estimate_fee_blocks'] as num?,
+      rpcUrls: (json['rpc_urls'] as List<dynamic>?)
+          ?.map((dynamic e) => RpcUrl.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  final String coin;
+  final String? type;
+  final String? name;
+  final String? coingeckoId;
+  final String? livecoinwatchId;
+  final String? explorerUrl;
+  final String? explorerTxUrl;
+  final String? explorerAddressUrl;
+  final List<String>? supported;
+  final bool? active;
+  final bool? isTestnet;
+  final bool? currentlyEnabled;
+  final bool? walletOnly;
+  final String? fname;
+  final num? rpcport;
+  final num? mm2;
+  final num? chainId;
+  final num? requiredConfirmations;
+  final num? avgBlocktime;
+  final num? decimals;
+  final Protocol? protocol;
+  final String? derivationPath;
+  final String? contractAddress;
+  final String? parentCoin;
+  final String? swapContractAddress;
+  final String? fallbackSwapContract;
+  final List<Node>? nodes;
+  final String? explorerBlockUrl;
+  final String? tokenAddressUrl;
+  final String? trezorCoin;
+  final Links? links;
+  final num? pubtype;
+  final num? p2shtype;
+  final num? wiftype;
+  final num? txfee;
+  final num? dust;
+  final bool? segwit;
+  final List<Electrum>? electrum;
+  final String? signMessagePrefix;
+  final List<String>? lightWalletDServers;
+  final String? asset;
+  final num? txversion;
+  final num? overwintered;
+  final bool? requiresNotarization;
+  final num? checkpointHeight;
+  final num? checkpointBlocktime;
+  final String? binanceId;
+  final String? bech32Hrp;
+  final String? forkId;
+  final String? signatureVersion;
+  final String? confpath;
+  final num? matureConfirmations;
+  final List<String>? bchdUrls;
+  final List<String>? otherTypes;
+  final AddressFormat? addressFormat;
+  final bool? allowSlpUnsafeConf;
+  final String? slpPrefix;
+  final String? tokenId;
+  final String? forexId;
+  final num? isPoS;
+  final String? aliasTicker;
+  final String? estimateFeeMode;
+  final String? orderbookTicker;
+  final num? taddr;
+  final bool? forceMinRelayFee;
+  final bool? isClaimable;
+  final String? minimalClaimAmount;
+  final num? isPoSV;
+  final String? versionGroupId;
+  final String? consensusBranchId;
+  final num? estimateFeeBlocks;
+  final List<RpcUrl>? rpcUrls;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'coin': coin,
+      'type': type,
+      'name': name,
+      'coingecko_id': coingeckoId,
+      'livecoinwatch_id': livecoinwatchId,
+      'explorer_url': explorerUrl,
+      'explorer_tx_url': explorerTxUrl,
+      'explorer_address_url': explorerAddressUrl,
+      'supported': supported,
+      'active': active,
+      'is_testnet': isTestnet,
+      'currently_enabled': currentlyEnabled,
+      'wallet_only': walletOnly,
+      'fname': fname,
+      'rpcport': rpcport,
+      'mm2': mm2,
+      'chain_id': chainId,
+      'required_confirmations': requiredConfirmations,
+      'avg_blocktime': avgBlocktime,
+      'decimals': decimals,
+      'protocol': protocol?.toJson(),
+      'derivation_path': derivationPath,
+      'contractAddress': contractAddress,
+      'parent_coin': parentCoin,
+      'swap_contract_address': swapContractAddress,
+      'fallback_swap_contract': fallbackSwapContract,
+      'nodes': nodes?.map((Node e) => e.toJson()).toList(),
+      'explorer_block_url': explorerBlockUrl,
+      'token_address_url': tokenAddressUrl,
+      'trezor_coin': trezorCoin,
+      'links': links?.toJson(),
+      'pubtype': pubtype,
+      'p2shtype': p2shtype,
+      'wiftype': wiftype,
+      'txfee': txfee,
+      'dust': dust,
+      'segwit': segwit,
+      'electrum': electrum?.map((Electrum e) => e.toJson()).toList(),
+      'sign_message_refix': signMessagePrefix,
+      'light_wallet_d_servers': lightWalletDServers,
+      'asset': asset,
+      'txversion': txversion,
+      'overwintered': overwintered,
+      'requires_notarization': requiresNotarization,
+      'checkpoint_height': checkpointHeight,
+      'checkpoint_blocktime': checkpointBlocktime,
+      'binance_id': binanceId,
+      'bech32_hrp': bech32Hrp,
+      'forkId': forkId,
+      'signature_version': signatureVersion,
+      'confpath': confpath,
+      'mature_confirmations': matureConfirmations,
+      'bchd_urls': bchdUrls,
+      'other_types': otherTypes,
+      'address_format': addressFormat?.toJson(),
+      'allow_slp_unsafe_conf': allowSlpUnsafeConf,
+      'slp_prefix': slpPrefix,
+      'token_id': tokenId,
+      'forex_id': forexId,
+      'isPoS': isPoS,
+      'alias_ticker': aliasTicker,
+      'estimate_fee_mode': estimateFeeMode,
+      'orderbook_ticker': orderbookTicker,
+      'taddr': taddr,
+      'force_min_relay_fee': forceMinRelayFee,
+      'is_claimable': isClaimable,
+      'minimal_claim_amount': minimalClaimAmount,
+      'isPoSV': isPoSV,
+      'version_group_id': versionGroupId,
+      'consensus_branch_id': consensusBranchId,
+      'estimate_fee_blocks': estimateFeeBlocks,
+      'rpc_urls': rpcUrls?.map((RpcUrl e) => e.toJson()).toList(),
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[
+        coin,
+        type,
+        name,
+        coingeckoId,
+        livecoinwatchId,
+        explorerUrl,
+        explorerTxUrl,
+        explorerAddressUrl,
+        supported,
+        active,
+        isTestnet,
+        currentlyEnabled,
+        walletOnly,
+        fname,
+        rpcport,
+        mm2,
+        chainId,
+        requiredConfirmations,
+        avgBlocktime,
+        decimals,
+        protocol,
+        derivationPath,
+        contractAddress,
+        parentCoin,
+        swapContractAddress,
+        fallbackSwapContract,
+        nodes,
+        explorerBlockUrl,
+        tokenAddressUrl,
+        trezorCoin,
+        links,
+        pubtype,
+        p2shtype,
+        wiftype,
+        txfee,
+        dust,
+        segwit,
+        electrum,
+        signMessagePrefix,
+        lightWalletDServers,
+        asset,
+        txversion,
+        overwintered,
+        requiresNotarization,
+        checkpointHeight,
+        checkpointBlocktime,
+        binanceId,
+        bech32Hrp,
+        forkId,
+        signatureVersion,
+        confpath,
+        matureConfirmations,
+        bchdUrls,
+        otherTypes,
+        addressFormat,
+        allowSlpUnsafeConf,
+        slpPrefix,
+        tokenId,
+        forexId,
+        isPoS,
+        aliasTicker,
+        estimateFeeMode,
+        orderbookTicker,
+        taddr,
+        forceMinRelayFee,
+        isClaimable,
+        minimalClaimAmount,
+        isPoSV,
+        versionGroupId,
+        consensusBranchId,
+        estimateFeeBlocks,
+        rpcUrls,
+      ];
+
+  @override
+  String get primaryKey => coin;
+}

--- a/packages/komodo_coin_updates/lib/src/models/coin_config.dart
+++ b/packages/komodo_coin_updates/lib/src/models/coin_config.dart
@@ -1,13 +1,12 @@
 import 'package:equatable/equatable.dart';
 import 'package:hive/hive.dart';
+import 'package:komodo_coin_updates/src/models/address_format.dart';
+import 'package:komodo_coin_updates/src/models/electrum.dart';
+import 'package:komodo_coin_updates/src/models/links.dart';
+import 'package:komodo_coin_updates/src/models/node.dart';
+import 'package:komodo_coin_updates/src/models/protocol.dart';
+import 'package:komodo_coin_updates/src/models/rpc_url.dart';
 import 'package:komodo_coin_updates/src/persistence/persistence_provider.dart';
-
-import 'address_format.dart';
-import 'electrum.dart';
-import 'links.dart';
-import 'node.dart';
-import 'protocol.dart';
-import 'rpc_url.dart';
 
 part 'adapters/coin_config_adapter.dart';
 
@@ -97,9 +96,10 @@ class CoinConfig extends Equatable implements ObjectWithPrimaryKey<String> {
       explorerUrl: json['explorer_url'] as String?,
       explorerTxUrl: json['explorer_tx_url'] as String?,
       explorerAddressUrl: json['explorer_address_url'] as String?,
-      supported: (json['supported'] as List<dynamic>?)
-          ?.map((dynamic e) => e as String)
-          .toList(),
+      supported:
+          (json['supported'] as List<dynamic>?)
+              ?.map((dynamic e) => e as String)
+              .toList(),
       active: json['active'] as bool?,
       isTestnet: json['is_testnet'] as bool?,
       currentlyEnabled: json['currently_enabled'] as bool?,
@@ -111,36 +111,41 @@ class CoinConfig extends Equatable implements ObjectWithPrimaryKey<String> {
       requiredConfirmations: json['required_confirmations'] as num?,
       avgBlocktime: json['avg_blocktime'] as num?,
       decimals: json['decimals'] as num?,
-      protocol: json['protocol'] == null
-          ? null
-          : Protocol.fromJson(json['protocol'] as Map<String, dynamic>),
+      protocol:
+          json['protocol'] == null
+              ? null
+              : Protocol.fromJson(json['protocol'] as Map<String, dynamic>),
       derivationPath: json['derivation_path'] as String?,
       contractAddress: json['contractAddress'] as String?,
       parentCoin: json['parent_coin'] as String?,
       swapContractAddress: json['swap_contract_address'] as String?,
       fallbackSwapContract: json['fallback_swap_contract'] as String?,
-      nodes: (json['nodes'] as List<dynamic>?)
-          ?.map((dynamic e) => Node.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      nodes:
+          (json['nodes'] as List<dynamic>?)
+              ?.map((dynamic e) => Node.fromJson(e as Map<String, dynamic>))
+              .toList(),
       explorerBlockUrl: json['explorer_block_url'] as String?,
       tokenAddressUrl: json['token_address_url'] as String?,
       trezorCoin: json['trezor_coin'] as String?,
-      links: json['links'] == null
-          ? null
-          : Links.fromJson(json['links'] as Map<String, dynamic>),
+      links:
+          json['links'] == null
+              ? null
+              : Links.fromJson(json['links'] as Map<String, dynamic>),
       pubtype: json['pubtype'] as num?,
       p2shtype: json['p2shtype'] as num?,
       wiftype: json['wiftype'] as num?,
       txfee: json['txfee'] as num?,
       dust: json['dust'] as num?,
       segwit: json['segwit'] as bool?,
-      electrum: (json['electrum'] as List<dynamic>?)
-          ?.map((dynamic e) => Electrum.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      electrum:
+          (json['electrum'] as List<dynamic>?)
+              ?.map((dynamic e) => Electrum.fromJson(e as Map<String, dynamic>))
+              .toList(),
       signMessagePrefix: json['sign_message_refix'] as String?,
-      lightWalletDServers: (json['light_wallet_d_servers'] as List<dynamic>?)
-          ?.map((dynamic e) => e as String)
-          .toList(),
+      lightWalletDServers:
+          (json['light_wallet_d_servers'] as List<dynamic>?)
+              ?.map((dynamic e) => e as String)
+              .toList(),
       asset: json['asset'] as String?,
       txversion: json['txversion'] as num?,
       overwintered: json['overwintered'] as num?,
@@ -153,17 +158,20 @@ class CoinConfig extends Equatable implements ObjectWithPrimaryKey<String> {
       signatureVersion: json['signature_version'] as String?,
       confpath: json['confpath'] as String?,
       matureConfirmations: json['mature_confirmations'] as num?,
-      bchdUrls: (json['bchd_urls'] as List<dynamic>?)
-          ?.map((dynamic e) => e as String)
-          .toList(),
-      otherTypes: (json['other_types'] as List<dynamic>?)
-          ?.map((dynamic e) => e as String)
-          .toList(),
-      addressFormat: json['address_format'] == null
-          ? null
-          : AddressFormat.fromJson(
-              json['address_format'] as Map<String, dynamic>,
-            ),
+      bchdUrls:
+          (json['bchd_urls'] as List<dynamic>?)
+              ?.map((dynamic e) => e as String)
+              .toList(),
+      otherTypes:
+          (json['other_types'] as List<dynamic>?)
+              ?.map((dynamic e) => e as String)
+              .toList(),
+      addressFormat:
+          json['address_format'] == null
+              ? null
+              : AddressFormat.fromJson(
+                json['address_format'] as Map<String, dynamic>,
+              ),
       allowSlpUnsafeConf: json['allow_slp_unsafe_conf'] as bool?,
       slpPrefix: json['slp_prefix'] as String?,
       tokenId: json['token_id'] as String?,
@@ -180,9 +188,10 @@ class CoinConfig extends Equatable implements ObjectWithPrimaryKey<String> {
       versionGroupId: json['version_group_id'] as String?,
       consensusBranchId: json['consensus_branch_id'] as String?,
       estimateFeeBlocks: json['estimate_fee_blocks'] as num?,
-      rpcUrls: (json['rpc_urls'] as List<dynamic>?)
-          ?.map((dynamic e) => RpcUrl.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      rpcUrls:
+          (json['rpc_urls'] as List<dynamic>?)
+              ?.map((dynamic e) => RpcUrl.fromJson(e as Map<String, dynamic>))
+              .toList(),
     );
   }
 
@@ -338,79 +347,79 @@ class CoinConfig extends Equatable implements ObjectWithPrimaryKey<String> {
 
   @override
   List<Object?> get props => <Object?>[
-        coin,
-        type,
-        name,
-        coingeckoId,
-        livecoinwatchId,
-        explorerUrl,
-        explorerTxUrl,
-        explorerAddressUrl,
-        supported,
-        active,
-        isTestnet,
-        currentlyEnabled,
-        walletOnly,
-        fname,
-        rpcport,
-        mm2,
-        chainId,
-        requiredConfirmations,
-        avgBlocktime,
-        decimals,
-        protocol,
-        derivationPath,
-        contractAddress,
-        parentCoin,
-        swapContractAddress,
-        fallbackSwapContract,
-        nodes,
-        explorerBlockUrl,
-        tokenAddressUrl,
-        trezorCoin,
-        links,
-        pubtype,
-        p2shtype,
-        wiftype,
-        txfee,
-        dust,
-        segwit,
-        electrum,
-        signMessagePrefix,
-        lightWalletDServers,
-        asset,
-        txversion,
-        overwintered,
-        requiresNotarization,
-        checkpointHeight,
-        checkpointBlocktime,
-        binanceId,
-        bech32Hrp,
-        forkId,
-        signatureVersion,
-        confpath,
-        matureConfirmations,
-        bchdUrls,
-        otherTypes,
-        addressFormat,
-        allowSlpUnsafeConf,
-        slpPrefix,
-        tokenId,
-        forexId,
-        isPoS,
-        aliasTicker,
-        estimateFeeMode,
-        orderbookTicker,
-        taddr,
-        forceMinRelayFee,
-        isClaimable,
-        minimalClaimAmount,
-        isPoSV,
-        versionGroupId,
-        consensusBranchId,
-        estimateFeeBlocks,
-        rpcUrls,
-      ];
+    coin,
+    type,
+    name,
+    coingeckoId,
+    livecoinwatchId,
+    explorerUrl,
+    explorerTxUrl,
+    explorerAddressUrl,
+    supported,
+    active,
+    isTestnet,
+    currentlyEnabled,
+    walletOnly,
+    fname,
+    rpcport,
+    mm2,
+    chainId,
+    requiredConfirmations,
+    avgBlocktime,
+    decimals,
+    protocol,
+    derivationPath,
+    contractAddress,
+    parentCoin,
+    swapContractAddress,
+    fallbackSwapContract,
+    nodes,
+    explorerBlockUrl,
+    tokenAddressUrl,
+    trezorCoin,
+    links,
+    pubtype,
+    p2shtype,
+    wiftype,
+    txfee,
+    dust,
+    segwit,
+    electrum,
+    signMessagePrefix,
+    lightWalletDServers,
+    asset,
+    txversion,
+    overwintered,
+    requiresNotarization,
+    checkpointHeight,
+    checkpointBlocktime,
+    binanceId,
+    bech32Hrp,
+    forkId,
+    signatureVersion,
+    confpath,
+    matureConfirmations,
+    bchdUrls,
+    otherTypes,
+    addressFormat,
+    allowSlpUnsafeConf,
+    slpPrefix,
+    tokenId,
+    forexId,
+    isPoS,
+    aliasTicker,
+    estimateFeeMode,
+    orderbookTicker,
+    taddr,
+    forceMinRelayFee,
+    isClaimable,
+    minimalClaimAmount,
+    isPoSV,
+    versionGroupId,
+    consensusBranchId,
+    estimateFeeBlocks,
+    rpcUrls,
+  ];
 
   @override
   String get primaryKey => coin;

--- a/packages/komodo_coin_updates/lib/src/models/coin_info.dart
+++ b/packages/komodo_coin_updates/lib/src/models/coin_info.dart
@@ -1,16 +1,12 @@
 import 'package:equatable/equatable.dart';
 import 'package:hive/hive.dart';
+import 'package:komodo_coin_updates/komodo_coin_updates.dart';
 import 'package:komodo_coin_updates/src/persistence/persistence_provider.dart';
-
-import '../../komodo_coin_updates.dart';
 
 part 'adapters/coin_info_adapter.dart';
 
 class CoinInfo extends Equatable implements ObjectWithPrimaryKey<String> {
-  const CoinInfo({
-    required this.coin,
-    required this.coinConfig,
-  });
+  const CoinInfo({required this.coin, required this.coinConfig});
 
   final Coin coin;
   final CoinConfig? coinConfig;

--- a/packages/komodo_coin_updates/lib/src/models/coin_info.dart
+++ b/packages/komodo_coin_updates/lib/src/models/coin_info.dart
@@ -1,0 +1,24 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+import 'package:komodo_persistence_layer/komodo_persistence_layer.dart';
+
+import '../../komodo_coin_updates.dart';
+
+part 'adapters/coin_info_adapter.dart';
+
+class CoinInfo extends Equatable implements ObjectWithPrimaryKey<String> {
+  const CoinInfo({
+    required this.coin,
+    required this.coinConfig,
+  });
+
+  final Coin coin;
+  final CoinConfig? coinConfig;
+
+  @override
+  String get primaryKey => coin.coin;
+
+  @override
+  // TODO(Francois): optimize for comparisons - decide on fields to use when comparing
+  List<Object?> get props => <Object?>[coin, coinConfig];
+}

--- a/packages/komodo_coin_updates/lib/src/models/coin_info.dart
+++ b/packages/komodo_coin_updates/lib/src/models/coin_info.dart
@@ -1,6 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:hive/hive.dart';
-import 'package:komodo_persistence_layer/komodo_persistence_layer.dart';
+import 'package:komodo_coin_updates/src/persistence/persistence_provider.dart';
 
 import '../../komodo_coin_updates.dart';
 

--- a/packages/komodo_coin_updates/lib/src/models/consensus_params.dart
+++ b/packages/komodo_coin_updates/lib/src/models/consensus_params.dart
@@ -31,12 +31,18 @@ class ConsensusParams extends Equatable {
       hrpSaplingExtendedFullViewingKey:
           json['hrp_sapling_extended_full_viewing_key'] as String?,
       hrpSaplingPaymentAddress: json['hrp_sapling_payment_address'] as String?,
-      b58PubkeyAddressPrefix: json['b58_pubkey_address_prefix'] != null
-          ? List<num>.from(json['b58_pubkey_address_prefix'] as List<dynamic>)
-          : null,
-      b58ScriptAddressPrefix: json['b58_script_address_prefix'] != null
-          ? List<num>.from(json['b58_script_address_prefix'] as List<dynamic>)
-          : null,
+      b58PubkeyAddressPrefix:
+          json['b58_pubkey_address_prefix'] != null
+              ? List<num>.from(
+                json['b58_pubkey_address_prefix'] as List<dynamic>,
+              )
+              : null,
+      b58ScriptAddressPrefix:
+          json['b58_script_address_prefix'] != null
+              ? List<num>.from(
+                json['b58_script_address_prefix'] as List<dynamic>,
+              )
+              : null,
     );
   }
 
@@ -70,16 +76,16 @@ class ConsensusParams extends Equatable {
 
   @override
   List<Object?> get props => <Object?>[
-        overwinterActivationHeight,
-        saplingActivationHeight,
-        blossomActivationHeight,
-        heartwoodActivationHeight,
-        canopyActivationHeight,
-        coinType,
-        hrpSaplingExtendedSpendingKey,
-        hrpSaplingExtendedFullViewingKey,
-        hrpSaplingPaymentAddress,
-        b58PubkeyAddressPrefix,
-        b58ScriptAddressPrefix,
-      ];
+    overwinterActivationHeight,
+    saplingActivationHeight,
+    blossomActivationHeight,
+    heartwoodActivationHeight,
+    canopyActivationHeight,
+    coinType,
+    hrpSaplingExtendedSpendingKey,
+    hrpSaplingExtendedFullViewingKey,
+    hrpSaplingPaymentAddress,
+    b58PubkeyAddressPrefix,
+    b58ScriptAddressPrefix,
+  ];
 }

--- a/packages/komodo_coin_updates/lib/src/models/consensus_params.dart
+++ b/packages/komodo_coin_updates/lib/src/models/consensus_params.dart
@@ -1,0 +1,85 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+
+part 'adapters/consensus_params_adapter.dart';
+
+class ConsensusParams extends Equatable {
+  const ConsensusParams({
+    this.overwinterActivationHeight,
+    this.saplingActivationHeight,
+    this.blossomActivationHeight,
+    this.heartwoodActivationHeight,
+    this.canopyActivationHeight,
+    this.coinType,
+    this.hrpSaplingExtendedSpendingKey,
+    this.hrpSaplingExtendedFullViewingKey,
+    this.hrpSaplingPaymentAddress,
+    this.b58PubkeyAddressPrefix,
+    this.b58ScriptAddressPrefix,
+  });
+
+  factory ConsensusParams.fromJson(Map<String, dynamic> json) {
+    return ConsensusParams(
+      overwinterActivationHeight: json['overwinter_activation_height'] as num?,
+      saplingActivationHeight: json['sapling_activation_height'] as num?,
+      blossomActivationHeight: json['blossom_activation_height'] as num?,
+      heartwoodActivationHeight: json['heartwood_activation_height'] as num?,
+      canopyActivationHeight: json['canopy_activation_height'] as num?,
+      coinType: json['coin_type'] as num?,
+      hrpSaplingExtendedSpendingKey:
+          json['hrp_sapling_extended_spending_key'] as String?,
+      hrpSaplingExtendedFullViewingKey:
+          json['hrp_sapling_extended_full_viewing_key'] as String?,
+      hrpSaplingPaymentAddress: json['hrp_sapling_payment_address'] as String?,
+      b58PubkeyAddressPrefix: json['b58_pubkey_address_prefix'] != null
+          ? List<num>.from(json['b58_pubkey_address_prefix'] as List<dynamic>)
+          : null,
+      b58ScriptAddressPrefix: json['b58_script_address_prefix'] != null
+          ? List<num>.from(json['b58_script_address_prefix'] as List<dynamic>)
+          : null,
+    );
+  }
+
+  final num? overwinterActivationHeight;
+  final num? saplingActivationHeight;
+  final num? blossomActivationHeight;
+  final num? heartwoodActivationHeight;
+  final num? canopyActivationHeight;
+  final num? coinType;
+  final String? hrpSaplingExtendedSpendingKey;
+  final String? hrpSaplingExtendedFullViewingKey;
+  final String? hrpSaplingPaymentAddress;
+  final List<num>? b58PubkeyAddressPrefix;
+  final List<num>? b58ScriptAddressPrefix;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'overwinter_activation_height': overwinterActivationHeight,
+      'sapling_activation_height': saplingActivationHeight,
+      'blossom_activation_height': blossomActivationHeight,
+      'heartwood_activation_height': heartwoodActivationHeight,
+      'canopy_activation_height': canopyActivationHeight,
+      'coin_type': coinType,
+      'hrp_sapling_extended_spending_key': hrpSaplingExtendedSpendingKey,
+      'hrp_sapling_extended_full_viewing_key': hrpSaplingExtendedFullViewingKey,
+      'hrp_sapling_payment_address': hrpSaplingPaymentAddress,
+      'b58_pubkey_address_prefix': b58PubkeyAddressPrefix,
+      'b58_script_address_prefix': b58ScriptAddressPrefix,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[
+        overwinterActivationHeight,
+        saplingActivationHeight,
+        blossomActivationHeight,
+        heartwoodActivationHeight,
+        canopyActivationHeight,
+        coinType,
+        hrpSaplingExtendedSpendingKey,
+        hrpSaplingExtendedFullViewingKey,
+        hrpSaplingPaymentAddress,
+        b58PubkeyAddressPrefix,
+        b58ScriptAddressPrefix,
+      ];
+}

--- a/packages/komodo_coin_updates/lib/src/models/contact.dart
+++ b/packages/komodo_coin_updates/lib/src/models/contact.dart
@@ -17,10 +17,7 @@ class Contact extends Equatable {
   final String? github;
 
   Map<String, dynamic> toJson() {
-    return <String, dynamic>{
-      'email': email,
-      'github': github,
-    };
+    return <String, dynamic>{'email': email, 'github': github};
   }
 
   @override

--- a/packages/komodo_coin_updates/lib/src/models/contact.dart
+++ b/packages/komodo_coin_updates/lib/src/models/contact.dart
@@ -1,0 +1,28 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+
+part 'adapters/contact_adapter.dart';
+
+class Contact extends Equatable {
+  const Contact({this.email, this.github});
+
+  factory Contact.fromJson(Map<String, dynamic> json) {
+    return Contact(
+      email: json['email'] as String?,
+      github: json['github'] as String?,
+    );
+  }
+
+  final String? email;
+  final String? github;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'email': email,
+      'github': github,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[email, github];
+}

--- a/packages/komodo_coin_updates/lib/src/models/electrum.dart
+++ b/packages/komodo_coin_updates/lib/src/models/electrum.dart
@@ -1,26 +1,22 @@
 import 'package:equatable/equatable.dart';
 import 'package:hive/hive.dart';
-import 'contact.dart';
+import 'package:komodo_coin_updates/src/models/contact.dart';
 
 part 'adapters/electrum_adapter.dart';
 
 // ignore: must_be_immutable
 class Electrum extends Equatable {
-  Electrum({
-    this.url,
-    this.wsUrl,
-    this.protocol,
-    this.contact,
-  });
+  Electrum({this.url, this.wsUrl, this.protocol, this.contact});
 
   factory Electrum.fromJson(Map<String, dynamic> json) {
     return Electrum(
       url: json['url'] as String?,
       wsUrl: json['ws_url'] as String?,
       protocol: json['protocol'] as String?,
-      contact: (json['contact'] as List<dynamic>?)
-          ?.map((dynamic e) => Contact.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      contact:
+          (json['contact'] as List<dynamic>?)
+              ?.map((dynamic e) => Contact.fromJson(e as Map<String, dynamic>))
+              .toList(),
     );
   }
 

--- a/packages/komodo_coin_updates/lib/src/models/electrum.dart
+++ b/packages/komodo_coin_updates/lib/src/models/electrum.dart
@@ -1,0 +1,43 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+import 'contact.dart';
+
+part 'adapters/electrum_adapter.dart';
+
+// ignore: must_be_immutable
+class Electrum extends Equatable {
+  Electrum({
+    this.url,
+    this.wsUrl,
+    this.protocol,
+    this.contact,
+  });
+
+  factory Electrum.fromJson(Map<String, dynamic> json) {
+    return Electrum(
+      url: json['url'] as String?,
+      wsUrl: json['ws_url'] as String?,
+      protocol: json['protocol'] as String?,
+      contact: (json['contact'] as List<dynamic>?)
+          ?.map((dynamic e) => Contact.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  final String? url;
+  String? wsUrl;
+  final String? protocol;
+  final List<Contact>? contact;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'url': url,
+      'ws_url': wsUrl,
+      'protocol': protocol,
+      'contact': contact?.map((Contact e) => e.toJson()).toList(),
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[url, wsUrl, protocol, contact];
+}

--- a/packages/komodo_coin_updates/lib/src/models/links.dart
+++ b/packages/komodo_coin_updates/lib/src/models/links.dart
@@ -4,10 +4,7 @@ import 'package:hive/hive.dart';
 part 'adapters/links_adapter.dart';
 
 class Links extends Equatable {
-  const Links({
-    this.github,
-    this.homepage,
-  });
+  const Links({this.github, this.homepage});
 
   factory Links.fromJson(Map<String, dynamic> json) {
     return Links(
@@ -20,10 +17,7 @@ class Links extends Equatable {
   final String? homepage;
 
   Map<String, dynamic> toJson() {
-    return <String, dynamic>{
-      'github': github,
-      'homepage': homepage,
-    };
+    return <String, dynamic>{'github': github, 'homepage': homepage};
   }
 
   @override

--- a/packages/komodo_coin_updates/lib/src/models/links.dart
+++ b/packages/komodo_coin_updates/lib/src/models/links.dart
@@ -1,0 +1,31 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+
+part 'adapters/links_adapter.dart';
+
+class Links extends Equatable {
+  const Links({
+    this.github,
+    this.homepage,
+  });
+
+  factory Links.fromJson(Map<String, dynamic> json) {
+    return Links(
+      github: json['github'] as String?,
+      homepage: json['homepage'] as String?,
+    );
+  }
+
+  final String? github;
+  final String? homepage;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'github': github,
+      'homepage': homepage,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[github, homepage];
+}

--- a/packages/komodo_coin_updates/lib/src/models/models.dart
+++ b/packages/komodo_coin_updates/lib/src/models/models.dart
@@ -1,0 +1,13 @@
+export 'address_format.dart';
+export 'checkpoint_block.dart';
+export 'coin.dart';
+export 'coin_config.dart';
+export 'consensus_params.dart';
+export 'contact.dart';
+export 'electrum.dart';
+export 'links.dart';
+export 'node.dart';
+export 'protocol.dart';
+export 'protocol_data.dart';
+export 'rpc_url.dart';
+export 'runtime_update_config.dart';

--- a/packages/komodo_coin_updates/lib/src/models/node.dart
+++ b/packages/komodo_coin_updates/lib/src/models/node.dart
@@ -1,7 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:hive/hive.dart';
 
-import '../../komodo_coin_updates.dart';
+import 'package:komodo_coin_updates/komodo_coin_updates.dart';
 
 part 'adapters/node_adapter.dart';
 
@@ -13,9 +13,10 @@ class Node extends Equatable {
       url: json['url'] as String?,
       wsUrl: json['ws_url'] as String?,
       guiAuth: (json['gui_auth'] ?? json['komodo_proxy']) as bool?,
-      contact: json['contact'] != null
-          ? Contact.fromJson(json['contact'] as Map<String, dynamic>)
-          : null,
+      contact:
+          json['contact'] != null
+              ? Contact.fromJson(json['contact'] as Map<String, dynamic>)
+              : null,
     );
   }
 

--- a/packages/komodo_coin_updates/lib/src/models/node.dart
+++ b/packages/komodo_coin_updates/lib/src/models/node.dart
@@ -1,0 +1,39 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+
+import '../../komodo_coin_updates.dart';
+
+part 'adapters/node_adapter.dart';
+
+class Node extends Equatable {
+  const Node({this.url, this.wsUrl, this.guiAuth, this.contact});
+
+  factory Node.fromJson(Map<String, dynamic> json) {
+    return Node(
+      url: json['url'] as String?,
+      wsUrl: json['ws_url'] as String?,
+      guiAuth: (json['gui_auth'] ?? json['komodo_proxy']) as bool?,
+      contact: json['contact'] != null
+          ? Contact.fromJson(json['contact'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+
+  final String? url;
+  final String? wsUrl;
+  final bool? guiAuth;
+  final Contact? contact;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'url': url,
+      'ws_url': wsUrl,
+      'gui_auth': guiAuth,
+      'komodo_proxy': guiAuth,
+      'contact': contact?.toJson(),
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[url, wsUrl, guiAuth, contact];
+}

--- a/packages/komodo_coin_updates/lib/src/models/protocol.dart
+++ b/packages/komodo_coin_updates/lib/src/models/protocol.dart
@@ -1,0 +1,39 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+
+import 'protocol_data.dart';
+
+part 'adapters/protocol_adapter.dart';
+
+class Protocol extends Equatable {
+  const Protocol({
+    this.type,
+    this.protocolData,
+    this.bip44,
+  });
+
+  factory Protocol.fromJson(Map<String, dynamic> json) {
+    return Protocol(
+      type: json['type'] as String?,
+      protocolData: (json['protocol_data'] != null)
+          ? ProtocolData.fromJson(json['protocol_data'] as Map<String, dynamic>)
+          : null,
+      bip44: json['bip44'] as String?,
+    );
+  }
+
+  final String? type;
+  final ProtocolData? protocolData;
+  final String? bip44;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'type': type,
+      'protocol_data': protocolData?.toJson(),
+      'bip44': bip44,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[type, protocolData, bip44];
+}

--- a/packages/komodo_coin_updates/lib/src/models/protocol.dart
+++ b/packages/komodo_coin_updates/lib/src/models/protocol.dart
@@ -1,23 +1,22 @@
 import 'package:equatable/equatable.dart';
 import 'package:hive/hive.dart';
 
-import 'protocol_data.dart';
+import 'package:komodo_coin_updates/src/models/protocol_data.dart';
 
 part 'adapters/protocol_adapter.dart';
 
 class Protocol extends Equatable {
-  const Protocol({
-    this.type,
-    this.protocolData,
-    this.bip44,
-  });
+  const Protocol({this.type, this.protocolData, this.bip44});
 
   factory Protocol.fromJson(Map<String, dynamic> json) {
     return Protocol(
       type: json['type'] as String?,
-      protocolData: (json['protocol_data'] != null)
-          ? ProtocolData.fromJson(json['protocol_data'] as Map<String, dynamic>)
-          : null,
+      protocolData:
+          (json['protocol_data'] != null)
+              ? ProtocolData.fromJson(
+                json['protocol_data'] as Map<String, dynamic>,
+              )
+              : null,
       bip44: json['bip44'] as String?,
     );
   }

--- a/packages/komodo_coin_updates/lib/src/models/protocol_data.dart
+++ b/packages/komodo_coin_updates/lib/src/models/protocol_data.dart
@@ -1,0 +1,95 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+
+import 'checkpoint_block.dart';
+import 'consensus_params.dart';
+
+part 'adapters/protocol_data_adapter.dart';
+
+class ProtocolData extends Equatable {
+  const ProtocolData({
+    this.platform,
+    this.contractAddress,
+    this.consensusParams,
+    this.checkPointBlock,
+    this.slpPrefix,
+    this.decimals,
+    this.tokenId,
+    this.requiredConfirmations,
+    this.denom,
+    this.accountPrefix,
+    this.chainId,
+    this.gasPrice,
+  });
+
+  factory ProtocolData.fromJson(Map<String, dynamic> json) {
+    return ProtocolData(
+      platform: json['platform'] as String?,
+      contractAddress: json['contract_address'] as String?,
+      consensusParams: json['consensus_params'] != null
+          ? ConsensusParams.fromJson(
+              json['consensus_params'] as Map<String, dynamic>,
+            )
+          : null,
+      checkPointBlock: json['check_point_block'] != null
+          ? CheckPointBlock.fromJson(
+              json['check_point_block'] as Map<String, dynamic>,
+            )
+          : null,
+      slpPrefix: json['slp_prefix'] as String?,
+      decimals: json['decimals'] as num?,
+      tokenId: json['token_id'] as String?,
+      requiredConfirmations: json['required_confirmations'] as num?,
+      denom: json['denom'] as String?,
+      accountPrefix: json['account_prefix'] as String?,
+      chainId: json['chain_id'] as String?,
+      gasPrice: json['gas_price'] as num?,
+    );
+  }
+
+  final String? platform;
+  final String? contractAddress;
+  final ConsensusParams? consensusParams;
+  final CheckPointBlock? checkPointBlock;
+  final String? slpPrefix;
+  final num? decimals;
+  final String? tokenId;
+  final num? requiredConfirmations;
+  final String? denom;
+  final String? accountPrefix;
+  final String? chainId;
+  final num? gasPrice;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'platform': platform,
+      'contract_address': contractAddress,
+      'consensus_params': consensusParams?.toJson(),
+      'check_point_block': checkPointBlock?.toJson(),
+      'slp_prefix': slpPrefix,
+      'decimals': decimals,
+      'token_id': tokenId,
+      'required_confirmations': requiredConfirmations,
+      'denom': denom,
+      'account_prefix': accountPrefix,
+      'chain_id': chainId,
+      'gas_price': gasPrice,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[
+        platform,
+        contractAddress,
+        consensusParams,
+        checkPointBlock,
+        slpPrefix,
+        decimals,
+        tokenId,
+        requiredConfirmations,
+        denom,
+        accountPrefix,
+        chainId,
+        gasPrice,
+      ];
+}

--- a/packages/komodo_coin_updates/lib/src/models/protocol_data.dart
+++ b/packages/komodo_coin_updates/lib/src/models/protocol_data.dart
@@ -1,8 +1,8 @@
 import 'package:equatable/equatable.dart';
 import 'package:hive/hive.dart';
 
-import 'checkpoint_block.dart';
-import 'consensus_params.dart';
+import 'package:komodo_coin_updates/src/models/checkpoint_block.dart';
+import 'package:komodo_coin_updates/src/models/consensus_params.dart';
 
 part 'adapters/protocol_data_adapter.dart';
 
@@ -26,16 +26,18 @@ class ProtocolData extends Equatable {
     return ProtocolData(
       platform: json['platform'] as String?,
       contractAddress: json['contract_address'] as String?,
-      consensusParams: json['consensus_params'] != null
-          ? ConsensusParams.fromJson(
-              json['consensus_params'] as Map<String, dynamic>,
-            )
-          : null,
-      checkPointBlock: json['check_point_block'] != null
-          ? CheckPointBlock.fromJson(
-              json['check_point_block'] as Map<String, dynamic>,
-            )
-          : null,
+      consensusParams:
+          json['consensus_params'] != null
+              ? ConsensusParams.fromJson(
+                json['consensus_params'] as Map<String, dynamic>,
+              )
+              : null,
+      checkPointBlock:
+          json['check_point_block'] != null
+              ? CheckPointBlock.fromJson(
+                json['check_point_block'] as Map<String, dynamic>,
+              )
+              : null,
       slpPrefix: json['slp_prefix'] as String?,
       decimals: json['decimals'] as num?,
       tokenId: json['token_id'] as String?,
@@ -79,17 +81,17 @@ class ProtocolData extends Equatable {
 
   @override
   List<Object?> get props => <Object?>[
-        platform,
-        contractAddress,
-        consensusParams,
-        checkPointBlock,
-        slpPrefix,
-        decimals,
-        tokenId,
-        requiredConfirmations,
-        denom,
-        accountPrefix,
-        chainId,
-        gasPrice,
-      ];
+    platform,
+    contractAddress,
+    consensusParams,
+    checkPointBlock,
+    slpPrefix,
+    decimals,
+    tokenId,
+    requiredConfirmations,
+    denom,
+    accountPrefix,
+    chainId,
+    gasPrice,
+  ];
 }

--- a/packages/komodo_coin_updates/lib/src/models/rpc_url.dart
+++ b/packages/komodo_coin_updates/lib/src/models/rpc_url.dart
@@ -7,17 +7,13 @@ class RpcUrl extends Equatable {
   const RpcUrl({this.url});
 
   factory RpcUrl.fromJson(Map<String, dynamic> json) {
-    return RpcUrl(
-      url: json['url'] as String?,
-    );
+    return RpcUrl(url: json['url'] as String?);
   }
 
   final String? url;
 
   Map<String, dynamic> toJson() {
-    return <String, dynamic>{
-      'url': url,
-    };
+    return <String, dynamic>{'url': url};
   }
 
   @override

--- a/packages/komodo_coin_updates/lib/src/models/rpc_url.dart
+++ b/packages/komodo_coin_updates/lib/src/models/rpc_url.dart
@@ -1,0 +1,25 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+
+part 'adapters/rpc_url_adapter.dart';
+
+class RpcUrl extends Equatable {
+  const RpcUrl({this.url});
+
+  factory RpcUrl.fromJson(Map<String, dynamic> json) {
+    return RpcUrl(
+      url: json['url'] as String?,
+    );
+  }
+
+  final String? url;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'url': url,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[url];
+}

--- a/packages/komodo_coin_updates/lib/src/models/runtime_update_config.dart
+++ b/packages/komodo_coin_updates/lib/src/models/runtime_update_config.dart
@@ -1,0 +1,45 @@
+import 'package:equatable/equatable.dart';
+
+class RuntimeUpdateConfig extends Equatable {
+  const RuntimeUpdateConfig({
+    required this.bundledCoinsRepoCommit,
+    required this.coinsRepoApiUrl,
+    required this.coinsRepoContentUrl,
+    required this.coinsRepoBranch,
+    required this.runtimeUpdatesEnabled,
+  });
+
+  factory RuntimeUpdateConfig.fromJson(Map<String, dynamic> json) {
+    return RuntimeUpdateConfig(
+      bundledCoinsRepoCommit: json['bundled_coins_repo_commit'] as String,
+      coinsRepoApiUrl: json['coins_repo_api_url'] as String,
+      coinsRepoContentUrl: json['coins_repo_content_url'] as String,
+      coinsRepoBranch: json['coins_repo_branch'] as String,
+      runtimeUpdatesEnabled: json['runtime_updates_enabled'] as bool,
+    );
+  }
+  final String bundledCoinsRepoCommit;
+  final String coinsRepoApiUrl;
+  final String coinsRepoContentUrl;
+  final String coinsRepoBranch;
+  final bool runtimeUpdatesEnabled;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'bundled_coins_repo_commit': bundledCoinsRepoCommit,
+      'coins_repo_api_url': coinsRepoApiUrl,
+      'coins_repo_content_url': coinsRepoContentUrl,
+      'coins_repo_branch': coinsRepoBranch,
+      'runtime_updates_enabled': runtimeUpdatesEnabled,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[
+        bundledCoinsRepoCommit,
+        coinsRepoApiUrl,
+        coinsRepoContentUrl,
+        coinsRepoBranch,
+        runtimeUpdatesEnabled,
+      ];
+}

--- a/packages/komodo_coin_updates/lib/src/models/runtime_update_config.dart
+++ b/packages/komodo_coin_updates/lib/src/models/runtime_update_config.dart
@@ -36,10 +36,10 @@ class RuntimeUpdateConfig extends Equatable {
 
   @override
   List<Object?> get props => <Object?>[
-        bundledCoinsRepoCommit,
-        coinsRepoApiUrl,
-        coinsRepoContentUrl,
-        coinsRepoBranch,
-        runtimeUpdatesEnabled,
-      ];
+    bundledCoinsRepoCommit,
+    coinsRepoApiUrl,
+    coinsRepoContentUrl,
+    coinsRepoBranch,
+    runtimeUpdatesEnabled,
+  ];
 }

--- a/packages/komodo_coin_updates/lib/src/persistence/hive/box.dart
+++ b/packages/komodo_coin_updates/lib/src/persistence/hive/box.dart
@@ -1,0 +1,97 @@
+import 'package:hive/hive.dart';
+
+import '../persistence_provider.dart';
+
+/// A [PersistenceProvider] that uses a Hive box as the underlying storage.
+///
+/// The type parameters are:
+/// - `K`: The type of the primary key of the objects that the provider stores.
+/// - `T`: The type of the objects that the provider stores. The objects must
+/// implement the [ObjectWithPrimaryKey] interface.
+class HiveBoxProvider<K, T extends ObjectWithPrimaryKey<K>>
+    extends PersistenceProvider<K, T> {
+  HiveBoxProvider({
+    required this.name,
+  });
+
+  HiveBoxProvider.init({
+    required this.name,
+    required Box<T> box,
+  }) : _box = box;
+
+  final String name;
+  Box<T>? _box;
+
+  static Future<HiveBoxProvider<K, T>>
+      create<K, T extends ObjectWithPrimaryKey<K>>({
+    required String name,
+  }) async {
+    final Box<T> box = await Hive.openBox<T>(name);
+    return HiveBoxProvider<K, T>.init(name: name, box: box);
+  }
+
+  @override
+  Future<void> delete(K key) async {
+    _box ??= await Hive.openBox<T>(name);
+    await _box!.delete(key);
+  }
+
+  @override
+  Future<void> deleteAll() async {
+    _box ??= await Hive.openBox<T>(name);
+    await _box!.deleteAll(_box!.keys);
+  }
+
+  @override
+  Future<T?> get(K key) async {
+    _box ??= await Hive.openBox<T>(name);
+    return _box!.get(key);
+  }
+
+  @override
+  Future<List<T?>> getAll() async {
+    _box ??= await Hive.openBox<T>(name);
+    return _box!.values.toList();
+  }
+
+  @override
+  Future<void> insert(T object) async {
+    _box ??= await Hive.openBox<T>(name);
+    await _box!.put(object.primaryKey, object);
+  }
+
+  @override
+  Future<void> insertAll(List<T> objects) async {
+    _box ??= await Hive.openBox<T>(name);
+
+    final Map<K, T> map = <K, T>{};
+    for (final T object in objects) {
+      map[object.primaryKey] = object;
+    }
+
+    await _box!.putAll(map);
+  }
+
+  @override
+  Future<void> update(T object) async {
+    // Hive replaces the object if it already exists.
+    await insert(object);
+  }
+
+  @override
+  Future<void> updateAll(List<T> objects) async {
+    await insertAll(objects);
+  }
+
+  @override
+  Future<bool> exists() async {
+    return Hive.boxExists(name);
+  }
+
+  @override
+  Future<bool> containsKey(K key) async {
+    _box ??= await Hive.openBox<T>(name);
+
+    return _box!.containsKey(key);
+  }
+}

--- a/packages/komodo_coin_updates/lib/src/persistence/hive/box.dart
+++ b/packages/komodo_coin_updates/lib/src/persistence/hive/box.dart
@@ -1,6 +1,6 @@
 import 'package:hive/hive.dart';
 
-import '../persistence_provider.dart';
+import 'package:komodo_coin_updates/src/persistence/persistence_provider.dart';
 
 /// A [PersistenceProvider] that uses a Hive box as the underlying storage.
 ///
@@ -10,23 +10,16 @@ import '../persistence_provider.dart';
 /// implement the [ObjectWithPrimaryKey] interface.
 class HiveBoxProvider<K, T extends ObjectWithPrimaryKey<K>>
     extends PersistenceProvider<K, T> {
-  HiveBoxProvider({
-    required this.name,
-  });
+  HiveBoxProvider({required this.name});
 
-  HiveBoxProvider.init({
-    required this.name,
-    required Box<T> box,
-  }) : _box = box;
+  HiveBoxProvider.init({required this.name, required Box<T> box}) : _box = box;
 
   final String name;
   Box<T>? _box;
 
   static Future<HiveBoxProvider<K, T>>
-      create<K, T extends ObjectWithPrimaryKey<K>>({
-    required String name,
-  }) async {
-    final Box<T> box = await Hive.openBox<T>(name);
+  create<K, T extends ObjectWithPrimaryKey<K>>({required String name}) async {
+    final box = await Hive.openBox<T>(name);
     return HiveBoxProvider<K, T>.init(name: name, box: box);
   }
 
@@ -64,8 +57,8 @@ class HiveBoxProvider<K, T extends ObjectWithPrimaryKey<K>>
   Future<void> insertAll(List<T> objects) async {
     _box ??= await Hive.openBox<T>(name);
 
-    final Map<K, T> map = <K, T>{};
-    for (final T object in objects) {
+    final map = <K, T>{};
+    for (final object in objects) {
       map[object.primaryKey] = object;
     }
 

--- a/packages/komodo_coin_updates/lib/src/persistence/hive/hive.dart
+++ b/packages/komodo_coin_updates/lib/src/persistence/hive/hive.dart
@@ -1,0 +1,2 @@
+export 'box.dart';
+export 'lazy_box.dart';

--- a/packages/komodo_coin_updates/lib/src/persistence/hive/lazy_box.dart
+++ b/packages/komodo_coin_updates/lib/src/persistence/hive/lazy_box.dart
@@ -1,6 +1,6 @@
 import 'package:hive/hive.dart';
 
-import '../persistence_provider.dart';
+import 'package:komodo_coin_updates/src/persistence/persistence_provider.dart';
 
 /// A [PersistenceProvider] that uses a Hive box as the underlying storage.
 ///
@@ -10,23 +10,17 @@ import '../persistence_provider.dart';
 /// implement the [ObjectWithPrimaryKey] interface.
 class HiveLazyBoxProvider<K, T extends ObjectWithPrimaryKey<K>>
     extends PersistenceProvider<K, T> {
-  HiveLazyBoxProvider({
-    required this.name,
-  });
+  HiveLazyBoxProvider({required this.name});
 
-  HiveLazyBoxProvider.init({
-    required this.name,
-    required LazyBox<T> box,
-  }) : _box = box;
+  HiveLazyBoxProvider.init({required this.name, required LazyBox<T> box})
+    : _box = box;
 
   final String name;
   LazyBox<T>? _box;
 
   static Future<HiveLazyBoxProvider<K, T>>
-      create<K, T extends ObjectWithPrimaryKey<K>>({
-    required String name,
-  }) async {
-    final LazyBox<T> box = await Hive.openLazyBox<T>(name);
+  create<K, T extends ObjectWithPrimaryKey<K>>({required String name}) async {
+    final box = await Hive.openLazyBox<T>(name);
     return HiveLazyBoxProvider<K, T>.init(name: name, box: box);
   }
 
@@ -52,9 +46,8 @@ class HiveLazyBoxProvider<K, T extends ObjectWithPrimaryKey<K>>
   Future<List<T?>> getAll() async {
     _box ??= await Hive.openLazyBox<T>(name);
 
-    final Iterable<Future<T?>> valueFutures =
-        _box!.keys.map((dynamic key) => _box!.get(key as K));
-    final List<T?> result = await Future.wait<T?>(valueFutures);
+    final valueFutures = _box!.keys.map((dynamic key) => _box!.get(key as K));
+    final result = await Future.wait<T?>(valueFutures);
     return result;
   }
 
@@ -68,8 +61,8 @@ class HiveLazyBoxProvider<K, T extends ObjectWithPrimaryKey<K>>
   Future<void> insertAll(List<T> objects) async {
     _box ??= await Hive.openLazyBox<T>(name);
 
-    final Map<K, T> map = <K, T>{};
-    for (final T object in objects) {
+    final map = <K, T>{};
+    for (final object in objects) {
       map[object.primaryKey] = object;
     }
 

--- a/packages/komodo_coin_updates/lib/src/persistence/hive/lazy_box.dart
+++ b/packages/komodo_coin_updates/lib/src/persistence/hive/lazy_box.dart
@@ -1,0 +1,101 @@
+import 'package:hive/hive.dart';
+
+import '../persistence_provider.dart';
+
+/// A [PersistenceProvider] that uses a Hive box as the underlying storage.
+///
+/// The type parameters are:
+/// - `K`: The type of the primary key of the objects that the provider stores.
+/// - `T`: The type of the objects that the provider stores. The objects must
+/// implement the [ObjectWithPrimaryKey] interface.
+class HiveLazyBoxProvider<K, T extends ObjectWithPrimaryKey<K>>
+    extends PersistenceProvider<K, T> {
+  HiveLazyBoxProvider({
+    required this.name,
+  });
+
+  HiveLazyBoxProvider.init({
+    required this.name,
+    required LazyBox<T> box,
+  }) : _box = box;
+
+  final String name;
+  LazyBox<T>? _box;
+
+  static Future<HiveLazyBoxProvider<K, T>>
+      create<K, T extends ObjectWithPrimaryKey<K>>({
+    required String name,
+  }) async {
+    final LazyBox<T> box = await Hive.openLazyBox<T>(name);
+    return HiveLazyBoxProvider<K, T>.init(name: name, box: box);
+  }
+
+  @override
+  Future<void> delete(K key) async {
+    _box ??= await Hive.openLazyBox<T>(name);
+    await _box!.delete(key);
+  }
+
+  @override
+  Future<void> deleteAll() async {
+    _box ??= await Hive.openLazyBox<T>(name);
+    await _box!.deleteAll(_box!.keys);
+  }
+
+  @override
+  Future<T?> get(K key) async {
+    _box ??= await Hive.openLazyBox<T>(name);
+    return _box!.get(key);
+  }
+
+  @override
+  Future<List<T?>> getAll() async {
+    _box ??= await Hive.openLazyBox<T>(name);
+
+    final Iterable<Future<T?>> valueFutures =
+        _box!.keys.map((dynamic key) => _box!.get(key as K));
+    final List<T?> result = await Future.wait<T?>(valueFutures);
+    return result;
+  }
+
+  @override
+  Future<void> insert(T object) async {
+    _box ??= await Hive.openLazyBox<T>(name);
+    await _box!.put(object.primaryKey, object);
+  }
+
+  @override
+  Future<void> insertAll(List<T> objects) async {
+    _box ??= await Hive.openLazyBox<T>(name);
+
+    final Map<K, T> map = <K, T>{};
+    for (final T object in objects) {
+      map[object.primaryKey] = object;
+    }
+
+    await _box!.putAll(map);
+  }
+
+  @override
+  Future<void> update(T object) async {
+    // Hive replaces the object if it already exists.
+    await insert(object);
+  }
+
+  @override
+  Future<void> updateAll(List<T> objects) async {
+    await insertAll(objects);
+  }
+
+  @override
+  Future<bool> exists() async {
+    return Hive.boxExists(name);
+  }
+
+  @override
+  Future<bool> containsKey(K key) async {
+    _box ??= await Hive.openLazyBox<T>(name);
+
+    return _box!.containsKey(key);
+  }
+}

--- a/packages/komodo_coin_updates/lib/src/persistence/persisted_types.dart
+++ b/packages/komodo_coin_updates/lib/src/persistence/persisted_types.dart
@@ -1,6 +1,6 @@
 import 'package:hive/hive.dart';
 
-import 'persistence_provider.dart';
+import 'package:komodo_coin_updates/src/persistence/persistence_provider.dart';
 
 abstract class PersistedBasicType<T> implements ObjectWithPrimaryKey<T> {
   PersistedBasicType(this.primaryKey, this.value);
@@ -21,14 +21,11 @@ class PersistedStringAdapter extends TypeAdapter<PersistedString> {
 
   @override
   PersistedString read(BinaryReader reader) {
-    final int numOfFields = reader.readByte();
-    final Map<int, dynamic> fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
-    return PersistedString(
-      fields[0] as String,
-      fields[1] as String,
-    );
+    return PersistedString(fields[0] as String, fields[1] as String);
   }
 
   @override

--- a/packages/komodo_coin_updates/lib/src/persistence/persisted_types.dart
+++ b/packages/komodo_coin_updates/lib/src/persistence/persisted_types.dart
@@ -1,0 +1,43 @@
+import 'package:hive/hive.dart';
+
+import 'persistence_provider.dart';
+
+abstract class PersistedBasicType<T> implements ObjectWithPrimaryKey<T> {
+  PersistedBasicType(this.primaryKey, this.value);
+
+  final T value;
+
+  @override
+  final T primaryKey;
+}
+
+class PersistedString extends PersistedBasicType<String> {
+  PersistedString(super.primaryKey, super.value);
+}
+
+class PersistedStringAdapter extends TypeAdapter<PersistedString> {
+  @override
+  final int typeId = 12;
+
+  @override
+  PersistedString read(BinaryReader reader) {
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return PersistedString(
+      fields[0] as String,
+      fields[1] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, PersistedString obj) {
+    writer
+      ..writeByte(2)
+      ..writeByte(0)
+      ..write(obj.primaryKey)
+      ..writeByte(1)
+      ..write(obj.value);
+  }
+}

--- a/packages/komodo_coin_updates/lib/src/persistence/persistence_provider.dart
+++ b/packages/komodo_coin_updates/lib/src/persistence/persistence_provider.dart
@@ -1,0 +1,36 @@
+/// A generic interface for objects that have a primary key.
+///
+/// This interface is used to define the primary key of objects that are stored
+/// in a persistence provider. The primary key is used to uniquely identify the
+/// object.
+///
+/// The type parameter `T` is the type of the primary key.
+abstract class ObjectWithPrimaryKey<T> {
+  T get primaryKey;
+}
+
+typedef TableWithStringPK = ObjectWithPrimaryKey<String>;
+typedef TableWithIntPK = ObjectWithPrimaryKey<int>;
+typedef TableWithDoublePK = ObjectWithPrimaryKey<double>;
+
+/// A generic interface for a persistence provider.
+///
+/// This interface defines the basic CRUD operations that a persistence provider
+/// should implement. The operations are asynchronous and return a [Future].
+///
+/// The type parameters are:
+/// - `K`: The type of the primary key of the objects that the provider stores.
+/// - `T`: The type of the objects that the provider stores. The objects must
+///  implement the [ObjectWithPrimaryKey] interface.
+abstract class PersistenceProvider<K, T extends ObjectWithPrimaryKey<K>> {
+  Future<T?> get(K key);
+  Future<List<T?>> getAll();
+  Future<bool> containsKey(K key);
+  Future<void> insert(T object);
+  Future<void> insertAll(List<T> objects);
+  Future<void> update(T object);
+  Future<void> updateAll(List<T> objects);
+  Future<void> delete(K key);
+  Future<void> deleteAll();
+  Future<bool> exists();
+}

--- a/packages/komodo_coin_updates/pubspec.yaml
+++ b/packages/komodo_coin_updates/pubspec.yaml
@@ -8,38 +8,12 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  http: 0.13.6 # dart.dev
-
-  komodo_persistence_layer:
-    path: ../komodo_persistence_layer/
-
-  # Approved via https://github.com/KomodoPlatform/komodo-wallet/pull/1106
-  flutter_bloc:
-    git:
-      url: https://github.com/KomodoPlatform/bloc.git
-      path: packages/flutter_bloc/
-      ref: 32d5002fb8b8a1e548fe8021d8468327680875ff # 8.1.1
-
-  # Approved via https://github.com/KomodoPlatform/komodo-wallet/pull/1106
-  equatable:
-    git:
-      url: https://github.com/KomodoPlatform/equatable.git
-      ref: 2117551ff3054f8edb1a58f63ffe1832a8d25623 #2.0.5
-
-  # Approved via https://github.com/KomodoPlatform/komodo-wallet/pull/1106
-  hive:
-    git:
-      url: https://github.com/KomodoPlatform/hive.git
-      path: hive/
-      ref: 470473ffc1ba39f6c90f31ababe0ee63b76b69fe #2.2.3
-
-  # Approved via https://github.com/KomodoPlatform/komodo-wallet/pull/1106
-  hive_flutter:
-    git:
-      url: https://github.com/KomodoPlatform/hive.git
-      path: hive_flutter/
-      ref: 0cbaab793be77b19b4740bc85d7ea6461b9762b4 #1.1.0
+  http: ^1.3.0 
+  flutter_bloc: ^9.1.0
+  equatable: ^2.0.7
+  hive: 2.2.3  
+  hive_flutter: 1.1.0
 
 dev_dependencies:
-  lints: ^2.1.0
+  lints: ^5.1.1
   test: ^1.24.0

--- a/packages/komodo_coin_updates/pubspec.yaml
+++ b/packages/komodo_coin_updates/pubspec.yaml
@@ -1,0 +1,45 @@
+name: komodo_coin_updates
+description: Runtime coin config update coin updates.
+version: 1.0.0
+publish_to: none # publishable packages can't have git dependencies
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+# Add regular dependencies here.
+dependencies:
+  http: 0.13.6 # dart.dev
+
+  komodo_persistence_layer:
+    path: ../komodo_persistence_layer/
+
+  # Approved via https://github.com/KomodoPlatform/komodo-wallet/pull/1106
+  flutter_bloc:
+    git:
+      url: https://github.com/KomodoPlatform/bloc.git
+      path: packages/flutter_bloc/
+      ref: 32d5002fb8b8a1e548fe8021d8468327680875ff # 8.1.1
+
+  # Approved via https://github.com/KomodoPlatform/komodo-wallet/pull/1106
+  equatable:
+    git:
+      url: https://github.com/KomodoPlatform/equatable.git
+      ref: 2117551ff3054f8edb1a58f63ffe1832a8d25623 #2.0.5
+
+  # Approved via https://github.com/KomodoPlatform/komodo-wallet/pull/1106
+  hive:
+    git:
+      url: https://github.com/KomodoPlatform/hive.git
+      path: hive/
+      ref: 470473ffc1ba39f6c90f31ababe0ee63b76b69fe #2.2.3
+
+  # Approved via https://github.com/KomodoPlatform/komodo-wallet/pull/1106
+  hive_flutter:
+    git:
+      url: https://github.com/KomodoPlatform/hive.git
+      path: hive_flutter/
+      ref: 0cbaab793be77b19b4740bc85d7ea6461b9762b4 #1.1.0
+
+dev_dependencies:
+  lints: ^2.1.0
+  test: ^1.24.0

--- a/packages/komodo_coin_updates/pubspec.yaml
+++ b/packages/komodo_coin_updates/pubspec.yaml
@@ -4,15 +4,17 @@ version: 1.0.0
 publish_to: none # publishable packages can't have git dependencies
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0 <3.30.0"
 
 # Add regular dependencies here.
 dependencies:
-  http: ^1.3.0 
-  flutter_bloc: ^9.1.0
   equatable: ^2.0.7
+  flutter_bloc: ^9.1.0
   hive: 2.2.3  
   hive_flutter: 1.1.0
+  http: ^1.3.0 
+  very_good_analysis: ^7.0.0
 
 dev_dependencies:
   lints: ^5.1.1

--- a/packages/komodo_coin_updates/test/komodo_coin_updates_test.dart
+++ b/packages/komodo_coin_updates/test/komodo_coin_updates_test.dart
@@ -1,0 +1,14 @@
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests', () {
+    setUp(() {
+      // Additional setup goes here.
+    });
+
+    test('First Test', () {
+      // TODO(Francois): Implement test
+      throw UnimplementedError();
+    });
+  });
+}


### PR DESCRIPTION
Adds the`komodo_coin_updates` package from the `main` branch of komodo-wallet to the `packages/`. 

Modifications from the original:
- Copied persistence layer from a separate package into the komodo_coin_updates package
- Updated dependencies and added very_good_analysis
- Dart format and lint fixes fixes

I opted to leave the existing model adapters unmodified, as the `hive_generator` package struggled to parse the Coin and CoinInfo models. Manual intervention would be required for these models, which will likely be abandoned for their SDK counterparts later on anyway.