### PR TITLE
refactor(komodo_defi_framework): add static, global log verbosity flag

### DIFF
--- a/packages/komodo_defi_framework/lib/komodo_defi_framework.dart
+++ b/packages/komodo_defi_framework/lib/komodo_defi_framework.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:komodo_defi_framework/src/config/kdf_config.dart';
+import 'package:komodo_defi_framework/src/config/kdf_logging_config.dart';
 import 'package:komodo_defi_framework/src/config/kdf_startup_config.dart';
 import 'package:komodo_defi_framework/src/operations/kdf_operations_factory.dart';
 import 'package:komodo_defi_framework/src/operations/kdf_operations_interface.dart';
@@ -158,7 +159,9 @@ class KomodoDefiFramework implements ApiClient {
       request..setIfAbsentOrEmpty('userpass', _hostConfig.rpcPassword),
     ))
         .ensureJson();
-    _log('RPC response: ${response.toJsonString()}');
+    if (KdfLoggingConfig.verboseLogging) {
+      _log('RPC response: ${response.toJsonString()}');
+    }
     return response;
   }
 

--- a/packages/komodo_defi_framework/lib/src/config/kdf_logging_config.dart
+++ b/packages/komodo_defi_framework/lib/src/config/kdf_logging_config.dart
@@ -17,6 +17,5 @@ class KdfLoggingConfig {
   /// such as full RPC responses. Default is false to reduce log noise.
   static bool verboseLogging = false;
 
-  static bool get verboseDebugLogging =>
-      KdfLoggingConfig.verboseLogging && kDebugMode;
+  static bool get debugLogging => KdfLoggingConfig.verboseLogging && kDebugMode;
 }

--- a/packages/komodo_defi_framework/lib/src/config/kdf_logging_config.dart
+++ b/packages/komodo_defi_framework/lib/src/config/kdf_logging_config.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/foundation.dart';
+
+/// A temporary configuration class to control logging behaviors.
+///
+/// This class is intended to be a temporary solution for controlling
+/// logging verbosity and will be refactored into a more comprehensive
+/// logging system in the future.
+///
+/// TODO: Replace with a proper logging system that allows for more granular control.
+class KdfLoggingConfig {
+  /// Private constructor to prevent instantiation.
+  KdfLoggingConfig._();
+
+  /// Whether verbose logging is enabled.
+  ///
+  /// When true, additional log messages will be included in the log stream,
+  /// such as full RPC responses. Default is false to reduce log noise.
+  static bool verboseLogging = false;
+
+  static bool get verboseDebugLogging =>
+      KdfLoggingConfig.verboseLogging && kDebugMode;
+}

--- a/packages/komodo_defi_framework/lib/src/operations/kdf_operations_native.dart
+++ b/packages/komodo_defi_framework/lib/src/operations/kdf_operations_native.dart
@@ -207,7 +207,7 @@ class KdfOperationsNativeLibrary implements IKdfOperations {
 
   @override
   Future<Map<String, dynamic>> mm2Rpc(Map<String, dynamic> request) async {
-    if (KdfLoggingConfig.verboseDebugLogging) {
+    if (KdfLoggingConfig.debugLogging) {
       _log('mm2 config: ${_config.toJson().censored()}');
       _log('mm2Rpc request (pre-process): ${request.censored()}');
     }

--- a/packages/komodo_defi_framework/lib/src/operations/kdf_operations_native.dart
+++ b/packages/komodo_defi_framework/lib/src/operations/kdf_operations_native.dart
@@ -7,6 +7,7 @@ import 'package:ffi/ffi.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart';
 import 'package:komodo_defi_framework/src/config/kdf_config.dart';
+import 'package:komodo_defi_framework/src/config/kdf_logging_config.dart';
 import 'package:komodo_defi_framework/src/native/komodo_defi_framework_bindings_generated.dart';
 import 'package:komodo_defi_framework/src/operations/kdf_operations_interface.dart';
 import 'package:komodo_defi_framework/src/operations/kdf_operations_local_executable.dart';
@@ -173,7 +174,7 @@ class KdfOperationsNativeLibrary implements IKdfOperations {
     ).whenComplete(() => calloc.free(startParamsPtr));
 
     if (kDebugMode) _log('KDF started in ${timer.elapsedMilliseconds}ms');
-    await Future.delayed(const Duration(milliseconds: 500));
+    await Future<void>.delayed(const Duration(milliseconds: 500));
     if (kDebugMode) _log('KDF started with result: $result');
     if (kDebugMode) _log('Status after starting KDF: ${_kdfMainStatus()}');
 
@@ -206,8 +207,11 @@ class KdfOperationsNativeLibrary implements IKdfOperations {
 
   @override
   Future<Map<String, dynamic>> mm2Rpc(Map<String, dynamic> request) async {
-    if (kDebugMode) _log('mm2 config: ${_config.toJson().censored()}');
-    if (kDebugMode) _log('mm2Rpc request (pre-process): ${request.censored()}');
+    if (KdfLoggingConfig.verboseDebugLogging) {
+      _log('mm2 config: ${_config.toJson().censored()}');
+      _log('mm2Rpc request (pre-process): ${request.censored()}');
+    }
+
     request['userpass'] = _config.rpcPassword;
     final response = await _client.post(
       _url,

--- a/packages/komodo_defi_framework/lib/src/operations/kdf_operations_remote.dart
+++ b/packages/komodo_defi_framework/lib/src/operations/kdf_operations_remote.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 import 'package:komodo_defi_framework/src/config/kdf_config.dart';
+import 'package:komodo_defi_framework/src/config/kdf_logging_config.dart';
 import 'package:komodo_defi_framework/src/operations/kdf_operations_interface.dart';
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 
@@ -157,7 +158,9 @@ class KdfOperationsRemote implements IKdfOperations {
       request['userpass'] = _userpass;
     }
 
-    _logCallback('mm2Rpc request: ${json.encode(request.censored())}');
+    if (KdfLoggingConfig.verboseLogging) {
+      _logCallback('mm2Rpc request: ${json.encode(request.censored())}');
+    }
 
     late final http.Response response;
 

--- a/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
+++ b/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:js_interop' as js_interop;
 import 'dart:js_interop_unsafe';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:http/http.dart';
@@ -242,7 +241,7 @@ class KdfOperationsWasm implements IKdfOperations {
 
   /// Makes the JavaScript RPC call and returns the raw JS response
   Future<js_interop.JSObject> _makeJsCall(JsonMap request) async {
-    if (KdfLoggingConfig.verboseDebugLogging) {
+    if (KdfLoggingConfig.debugLogging) {
       _log('mm2Rpc request: ${request.censored()}');
     }
     request['userpass'] = _config.rpcPassword;
@@ -281,7 +280,7 @@ class KdfOperationsWasm implements IKdfOperations {
       );
     }
 
-    if (KdfLoggingConfig.verboseDebugLogging) {
+    if (KdfLoggingConfig.debugLogging) {
       _log('Raw JS response: $jsResponse');
     }
     return jsResponse as js_interop.JSObject;
@@ -322,7 +321,7 @@ class KdfOperationsWasm implements IKdfOperations {
       );
     }
 
-    if (KdfLoggingConfig.verboseDebugLogging) {
+    if (KdfLoggingConfig.debugLogging) {
       _log('JS response validated: $dartResponse');
     }
   }

--- a/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
+++ b/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:http/http.dart';
 import 'package:komodo_defi_framework/komodo_defi_framework.dart';
+import 'package:komodo_defi_framework/src/config/kdf_logging_config.dart';
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:mutex/mutex.dart';
 
@@ -241,7 +242,9 @@ class KdfOperationsWasm implements IKdfOperations {
 
   /// Makes the JavaScript RPC call and returns the raw JS response
   Future<js_interop.JSObject> _makeJsCall(JsonMap request) async {
-    if (kDebugMode) _log('mm2Rpc request: ${request.censored()}');
+    if (KdfLoggingConfig.verboseDebugLogging) {
+      _log('mm2Rpc request: ${request.censored()}');
+    }
     request['userpass'] = _config.rpcPassword;
 
     final jsRequest = request.jsify() as js_interop.JSObject?;
@@ -278,7 +281,9 @@ class KdfOperationsWasm implements IKdfOperations {
       );
     }
 
-    if (kDebugMode) _log('Raw JS response: $jsResponse');
+    if (KdfLoggingConfig.verboseDebugLogging) {
+      _log('Raw JS response: $jsResponse');
+    }
     return jsResponse as js_interop.JSObject;
   }
 
@@ -315,6 +320,10 @@ class KdfOperationsWasm implements IKdfOperations {
         'Invalid response format for method ${request['method']}\nResponse: '
         '$dartResponse\nRaw JS Response: $jsResponse\nRequest: $request',
       );
+    }
+
+    if (KdfLoggingConfig.verboseDebugLogging) {
+      _log('JS response validated: $dartResponse');
     }
   }
 


### PR DESCRIPTION
Currently limited to the `komodo_defi_framework` package which is the source of the majority of log messages