### PR TITLE
fix(native-auth-ops): remove exceptions from logs in KDF restart function

### DIFF
--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -63,7 +63,7 @@
     "coins": {
         "fetch_at_build_enabled": true,
         "update_commit_on_build": true,
-        "bundled_coins_repo_commit": "de34ec7af46a0512ea4a107a6f9c9f18d2191536",
+        "bundled_coins_repo_commit": "57c196726f67cabb242bfce9b39ab04b10001ec5",
         "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",
         "coins_repo_content_url": "https://komodoplatform.github.io/coins",
         "coins_repo_branch": "master",

--- a/packages/komodo_defi_sdk/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/komodo_defi_sdk/example/ios/Runner.xcodeproj/project.pbxproj
@@ -294,9 +294,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -370,9 +374,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/packages/komodo_defi_sdk/example/ios/Runner/Info.plist
+++ b/packages/komodo_defi_sdk/example/ios/Runner/Info.plist
@@ -26,12 +26,6 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>
@@ -39,6 +33,12 @@
 	</dict>
 	<key>NSDocumentsFolderUsageDescription</key>
 	<string>This app needs access to documents folder to store database files.</string>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/packages/komodo_defi_sdk/example/web/kdf/res/kdf_wrapper.dart
+++ b/packages/komodo_defi_sdk/example/web/kdf/res/kdf_wrapper.dart
@@ -1,5 +1,6 @@
 // NB! This file is not currently used and will possibly be removed in the
-// future.
+// future. We can consider migrating the KDF JS bootstrapper to Dart and
+// compile to JavaScript.
 
 // ignore_for_file: avoid_dynamic_calls
 

--- a/packages/komodo_defi_types/lib/src/utils/security_utils.dart
+++ b/packages/komodo_defi_types/lib/src/utils/security_utils.dart
@@ -71,6 +71,7 @@ extension CensoredJsonMap on JsonMap {
   JsonMap censored() {
     // Search recursively for the following keys and replace their values
     // with "*" characters.
+    // TODO: consider adding regex or wildcard support for "*password*" or "*key*"
     const sensitive = [
       'seed',
       'userpass',
@@ -86,6 +87,7 @@ extension CensoredJsonMap on JsonMap {
       'privkey',
       'userpass',
       'rpc_password',
+      'wallet_password',
     ];
 
     return censorKeys(sensitive);


### PR DESCRIPTION
Removes `findExceptionsInLog` from the `_restartKdf` function, which is re-throwing connection errors from RPCs like the one below. These errors are innocuous errors, usually seen while KDF is restarting during a login. 

Also adds logic to wait for the RPC to be up in native `kdfMain` rather than a static 500ms delay.

```text
I/flutter (22277): Error getting KDF version: ClientException with SocketException: Connection refused (OS Error: Connection refused, errno = 111), address = localhost, port = 42740, uri=http://localhost:7783
```