### PR TITLE
fix(ui): convert error display to stateful widget to toggle detailed error message

### DIFF
--- a/packages/komodo_ui/lib/src/defi/withdraw/withdraw_error_display.dart
+++ b/packages/komodo_ui/lib/src/defi/withdraw/withdraw_error_display.dart
@@ -75,30 +75,67 @@ class _ErrorDisplayState extends State<ErrorDisplay> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        widget.message,
-                        style: theme.textTheme.titleSmall?.copyWith(
-                          color:
-                              widget.isWarning
-                                  ? theme.colorScheme.onTertiaryContainer
-                                  : theme.colorScheme.onErrorContainer,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      if (shouldShowDetailedMessage) ...[
-                        const SizedBox(height: 8),
-                        SelectableText(
-                          widget.detailedMessage!,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color:
-                                widget.isWarning
-                                    ? theme.colorScheme.onTertiaryContainer
-                                        .withValues(alpha: 0.8)
-                                    : theme.colorScheme.onErrorContainer
-                                        .withValues(alpha: 0.8),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              widget.message,
+                              style: theme.textTheme.titleSmall?.copyWith(
+                                color:
+                                    widget.isWarning
+                                        ? theme.colorScheme.onTertiaryContainer
+                                        : theme.colorScheme.onErrorContainer,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
                           ),
-                        ),
-                      ],
+                          if (widget.detailedMessage != null)
+                            TextButton(
+                              onPressed: () {
+                                // If the widget showDetails override is present, then
+                                // we don't want to toggle the showDetailedMessage state
+                                if (widget.showDetails) {
+                                  return;
+                                }
+
+                                setState(() {
+                                  showDetailedMessage = !showDetailedMessage;
+                                });
+                              },
+                              child: Text(
+                                shouldShowDetailedMessage
+                                    ? 'Hide Details'
+                                    : 'Show Details',
+                                style: TextStyle(color: color),
+                              ),
+                            ),
+                        ],
+                      ),
+                      AnimatedSize(
+                        duration: const Duration(milliseconds: 200),
+                        curve: Curves.easeInOut,
+                        child:
+                            shouldShowDetailedMessage
+                                ? Padding(
+                                  padding: const EdgeInsets.only(top: 8),
+                                  child: SelectableText(
+                                    widget.detailedMessage!,
+                                    style: theme.textTheme.bodySmall?.copyWith(
+                                      color:
+                                          widget.isWarning
+                                              ? theme
+                                                  .colorScheme
+                                                  .onTertiaryContainer
+                                                  .withValues(alpha: 0.8)
+                                              : theme
+                                                  .colorScheme
+                                                  .onErrorContainer
+                                                  .withValues(alpha: 0.8),
+                                    ),
+                                  ),
+                                )
+                                : const SizedBox.shrink(),
+                      ),
                     ],
                   ),
                 ),
@@ -113,27 +150,6 @@ class _ErrorDisplayState extends State<ErrorDisplay> {
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  if (widget.detailedMessage != null)
-                    TextButton(
-                      onPressed: () {
-                        // If the widget showDetails override is present, then
-                        // we don't want to toggle the showDetailedMessage state
-                        if (widget.showDetails) {
-                          return;
-                        }
-
-                        setState(() {
-                          showDetailedMessage = !showDetailedMessage;
-                        });
-                      },
-                      child: Text(
-                        shouldShowDetailedMessage
-                            ? 'Hide Details'
-                            : 'Show Details',
-                        style: TextStyle(color: color),
-                      ),
-                    ),
-                  const SizedBox(width: 12),
                   if (widget.actionLabel != null &&
                       widget.onActionPressed != null)
                     ElevatedButton(

--- a/packages/komodo_ui/lib/src/defi/withdraw/withdraw_error_display.dart
+++ b/packages/komodo_ui/lib/src/defi/withdraw/withdraw_error_display.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class ErrorDisplay extends StatelessWidget {
+class ErrorDisplay extends StatefulWidget {
   const ErrorDisplay({
     required this.message,
     this.icon,
@@ -23,18 +23,31 @@ class ErrorDisplay extends StatelessWidget {
   final bool showDetails;
 
   @override
+  State<ErrorDisplay> createState() => _ErrorDisplayState();
+}
+
+class _ErrorDisplayState extends State<ErrorDisplay> {
+  bool showDetailedMessage = false;
+
+  /// Shows the detailed error message if the override is true, or if the user
+  /// has toggled the detailed message to be shown.
+  bool get shouldShowDetailedMessage =>
+      widget.detailedMessage != null &&
+      (widget.showDetails || showDetailedMessage);
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
     // Determine color based on whether this is a warning or error
     final color =
-        isWarning ? theme.colorScheme.tertiary : theme.colorScheme.error;
+        widget.isWarning ? theme.colorScheme.tertiary : theme.colorScheme.error;
 
     // Determine background and container design
     final backgroundColor =
-        isWarning
-            ? theme.colorScheme.tertiaryContainer.withOpacity(0.7)
-            : theme.colorScheme.errorContainer.withOpacity(0.7);
+        widget.isWarning
+            ? theme.colorScheme.tertiaryContainer.withValues(alpha: 0.7)
+            : theme.colorScheme.errorContainer.withValues(alpha: 0.7);
 
     return Card(
       elevation: 0,
@@ -50,8 +63,8 @@ class ErrorDisplay extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Icon(
-                  icon ??
-                      (isWarning
+                  widget.icon ??
+                      (widget.isWarning
                           ? Icons.warning_amber_rounded
                           : Icons.error_outline),
                   color: color,
@@ -63,26 +76,26 @@ class ErrorDisplay extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        message,
+                        widget.message,
                         style: theme.textTheme.titleSmall?.copyWith(
                           color:
-                              isWarning
+                              widget.isWarning
                                   ? theme.colorScheme.onTertiaryContainer
                                   : theme.colorScheme.onErrorContainer,
                           fontWeight: FontWeight.bold,
                         ),
                       ),
-                      if (detailedMessage != null && showDetails) ...[
+                      if (shouldShowDetailedMessage) ...[
                         const SizedBox(height: 8),
-                        Text(
-                          detailedMessage!,
+                        SelectableText(
+                          widget.detailedMessage!,
                           style: theme.textTheme.bodySmall?.copyWith(
                             color:
-                                isWarning
+                                widget.isWarning
                                     ? theme.colorScheme.onTertiaryContainer
-                                        .withOpacity(0.8)
+                                        .withValues(alpha: 0.8)
                                     : theme.colorScheme.onErrorContainer
-                                        .withOpacity(0.8),
+                                        .withValues(alpha: 0.8),
                           ),
                         ),
                       ],
@@ -91,35 +104,49 @@ class ErrorDisplay extends StatelessWidget {
                 ),
               ],
             ),
-            if (child != null) ...[const SizedBox(height: 16), child!],
-            if (actionLabel != null && onActionPressed != null) ...[
+            if (widget.child != null) ...[
+              const SizedBox(height: 16),
+              widget.child!,
+            ],
+            ...[
               const SizedBox(height: 16),
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  if (detailedMessage != null)
+                  if (widget.detailedMessage != null)
                     TextButton(
                       onPressed: () {
-                        // Show detailed error message or toggle visibility
-                        // This would need state management in a StatefulWidget
+                        // If the widget showDetails override is present, then
+                        // we don't want to toggle the showDetailedMessage state
+                        if (widget.showDetails) {
+                          return;
+                        }
+
+                        setState(() {
+                          showDetailedMessage = !showDetailedMessage;
+                        });
                       },
                       child: Text(
-                        showDetails ? 'Hide Details' : 'Show Details',
+                        shouldShowDetailedMessage
+                            ? 'Hide Details'
+                            : 'Show Details',
                         style: TextStyle(color: color),
                       ),
                     ),
                   const SizedBox(width: 12),
-                  ElevatedButton(
-                    onPressed: onActionPressed,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: color,
-                      foregroundColor:
-                          isWarning
-                              ? theme.colorScheme.onTertiary
-                              : theme.colorScheme.onError,
+                  if (widget.actionLabel != null &&
+                      widget.onActionPressed != null)
+                    ElevatedButton(
+                      onPressed: widget.onActionPressed,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: color,
+                        foregroundColor:
+                            widget.isWarning
+                                ? theme.colorScheme.onTertiary
+                                : theme.colorScheme.onError,
+                      ),
+                      child: Text(widget.actionLabel!),
                     ),
-                    child: Text(actionLabel!),
-                  ),
                 ],
               ),
             ],


### PR DESCRIPTION
Simplifies the implementation of `ErrorDisplay` by enabling the show/hide details text toggle button by default if `detailedMessage` is provided. This also makes the detailed error text selectable.

```dart
ErrorDisplay(
  message: LocaleKeys.withdrawPreviewError.tr(),
  detailedMessage: state.previewError!.message,
)
```

<img width="952" alt="image" src="https://github.com/user-attachments/assets/5c5e2f96-60d9-4c11-9c6b-782162b531fb" />

<img width="952" alt="image" src="https://github.com/user-attachments/assets/a7349e74-45e9-4ccf-a21b-1db0c96f0588" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the error display component to allow users to toggle the visibility of detailed error messages, providing improved clarity and control when reviewing error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->