### PR TITLE
ci: add GitHub Actions workflow to roll KDF version automatically

### DIFF
--- a/.github/workflows/kdf-version-roll.yml
+++ b/.github/workflows/kdf-version-roll.yml
@@ -1,0 +1,194 @@
+name: Roll KDF Version
+
+on:
+  schedule:
+    # Run daily at midnight (UTC)
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to check for rolls (dev or main)"
+        required: false
+        default: ""
+        type: string
+
+jobs:
+  check-for-updates:
+    runs-on: ubuntu-latest
+    outputs:
+      has_updates: ${{ steps.check-updates.outputs.has_updates }}
+      branch: ${{ steps.determine-branch.outputs.branch }}
+      current_commit: ${{ steps.current-details.outputs.commit }}
+      new_commit: ${{ steps.check-updates.outputs.new_commit }}
+      source_urls: ${{ steps.get-source-urls.outputs.source_urls }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Dart SDK
+        uses: dart-lang/setup-dart@v1
+
+      - name: Install dependencies
+        run: |
+          cd packages/komodo_wallet_cli
+          dart pub get
+
+      - name: Determine branch from config
+        id: determine-branch
+        run: |
+          BRANCH=$(cat packages/komodo_defi_framework/app_build/build_config.json | jq -r '.api.branch')
+          # If workflow dispatch provided a branch, use that instead
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.branch }}" ]]; then
+            BRANCH="${{ github.event.inputs.branch }}"
+          fi
+          echo "Using branch: $BRANCH"
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+
+      - name: Get source URLs from config
+        id: get-source-urls
+        run: |
+          SOURCE_URLS=$(cat packages/komodo_defi_framework/app_build/build_config.json | jq -c '.api.source_urls')
+          echo "source_urls=$SOURCE_URLS" >> $GITHUB_OUTPUT
+          echo "Source URLs: $SOURCE_URLS"
+
+      - name: Get current commit details
+        id: current-details
+        run: |
+          COMMIT=$(cat packages/komodo_defi_framework/app_build/build_config.json | jq -r '.api.api_commit_hash')
+          echo "commit=$COMMIT" >> $GITHUB_OUTPUT
+
+      - name: Check for new commit
+        id: check-updates
+        run: |
+          BRANCH="${{ steps.determine-branch.outputs.branch }}"
+          CURRENT_COMMIT="${{ steps.current-details.outputs.commit }}"
+
+          # Get latest commit for the branch
+          TOKEN=${{ secrets.GITHUB_TOKEN }}
+          RESPONSE=$(curl -s -H "Authorization: token $TOKEN" \
+            "https://api.github.com/repos/KomodoPlatform/komodo-defi-framework/commits/$BRANCH")
+          NEW_COMMIT=$(echo $RESPONSE | jq -r '.sha')
+
+          echo "Current commit: $CURRENT_COMMIT"
+          echo "Latest commit: $NEW_COMMIT"
+
+          if [[ "$CURRENT_COMMIT" != "$NEW_COMMIT" ]]; then
+            echo "New commit found!"
+            echo "has_updates=true" >> $GITHUB_OUTPUT
+            echo "new_commit=$NEW_COMMIT" >> $GITHUB_OUTPUT
+          else
+            echo "No updates available."
+            echo "has_updates=false" >> $GITHUB_OUTPUT
+          fi
+
+  roll-kdf-version:
+    needs: check-for-updates
+    if: ${{ needs.check-for-updates.outputs.has_updates == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Dart SDK
+        uses: dart-lang/setup-dart@v1
+
+      - name: Install dependencies
+        run: |
+          cd packages/komodo_wallet_cli
+          dart pub get
+
+      - name: Create branch for roll
+        run: |
+          BRANCH="${{ needs.check-for-updates.outputs.branch }}"
+          NEW_COMMIT="${{ needs.check-for-updates.outputs.new_commit }}"
+          SHORT_COMMIT="${NEW_COMMIT:0:7}"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
+          git checkout -b kdf-roll/$BRANCH-$SHORT_COMMIT
+
+      - name: Roll KDF version
+        id: roll-version
+        run: |
+          BRANCH="${{ needs.check-for-updates.outputs.branch }}"
+          CURRENT_COMMIT="${{ needs.check-for-updates.outputs.current_commit }}"
+          NEW_COMMIT="${{ needs.check-for-updates.outputs.new_commit }}"
+          SOURCE_URLS='${{ needs.check-for-updates.outputs.source_urls }}'
+
+          echo "Running update_api_config tool..."
+          cd packages/komodo_wallet_cli
+          mkdir -p ../komodo_defi_framework/app_build/temp_downloads
+
+          # Try each source URL in order until one succeeds
+          SUCCESS=false
+          for SOURCE_URL in $(echo $SOURCE_URLS | jq -r '.[]'); do
+            echo "Trying source URL: $SOURCE_URL"
+            
+            # Determine source type from URL
+            if [[ "$SOURCE_URL" == *"api.github.com"* ]]; then
+              SOURCE_TYPE="github"
+            else
+              SOURCE_TYPE="mirror"
+            fi
+            
+            echo "Using source type: $SOURCE_TYPE"
+            
+            # Try roll with this source
+            if dart bin/update_api_config.dart \
+              --branch "$BRANCH" \
+              --source "$SOURCE_TYPE" \
+              --config ../komodo_defi_framework/app_build/build_config.json \
+              --output-dir ../komodo_defi_framework/app_build/temp_downloads \
+              --verbose; then
+              
+              echo "Successfully rolled using $SOURCE_URL"
+              SUCCESS=true
+              break
+            else
+              echo "Failed to roll using $SOURCE_URL, trying next source..."
+            fi
+          done
+
+          if [ "$SUCCESS" = false ]; then
+            echo "All sources failed. Exiting with error."
+            exit 1
+          fi
+
+      - name: Commit changes
+        run: |
+          BRANCH="${{ needs.check-for-updates.outputs.branch }}"
+          NEW_COMMIT="${{ needs.check-for-updates.outputs.new_commit }}"
+          SHORT_COMMIT="${NEW_COMMIT:0:7}"
+
+          # Check if there are changes to commit
+          if git diff --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          git add packages/komodo_defi_framework/app_build/build_config.json
+          git commit -m "chore: roll KDF version to commit $SHORT_COMMIT for branch $BRANCH"
+          git push origin kdf-roll/$BRANCH-$SHORT_COMMIT
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ needs.check-for-updates.outputs.branch }}"
+          NEW_COMMIT="${{ needs.check-for-updates.outputs.new_commit }}"
+          SHORT_COMMIT="${NEW_COMMIT:0:7}"
+
+          PR_TITLE="chore: roll KDF version to commit $SHORT_COMMIT for branch $BRANCH"
+          PR_BODY="This PR rolls the KDF version to the latest commit ($SHORT_COMMIT) for the '$BRANCH' branch.
+
+          **Changes:**
+          - Rolled KDF version from \`${{ needs.check-for-updates.outputs.current_commit }}\` to \`$NEW_COMMIT\`
+
+          This PR was automatically generated by GitHub Actions."
+
+          gh pr create \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --base "$BRANCH" \
+            --head "kdf-roll/$BRANCH-$SHORT_COMMIT"


### PR DESCRIPTION
This commit adds a GitHub Actions workflow that:
- Runs daily and checks for new KDF versions on the configured branch
- Dynamically determines the correct source (GitHub or hosted mirror) based on `source_urls`
- Creates a PR to roll the KDF version when a new commit is available
- Handles both 'dev' and 'main' branches appropriately

The workflow tries each source URL in sequence until one succeeds, following the same approach used by the FetchDefiApiStep in the build process.