### PR TITLE
feat(auth): allow weak password in auth options

### DIFF
--- a/packages/komodo_defi_local_auth/lib/src/auth/auth_service.dart
+++ b/packages/komodo_defi_local_auth/lib/src/auth/auth_service.dart
@@ -143,6 +143,7 @@ class KdfAuthService implements IAuthService {
         walletPassword: password,
         allowRegistrations: false,
         hdEnabled: options.derivationMethod == DerivationMethod.hdWallet,
+        allowWeakPassword: options.allowWeakPassword,
       );
 
       final user = await _authenticateUser(config);
@@ -188,6 +189,7 @@ class KdfAuthService implements IAuthService {
       allowRegistrations: true,
       plaintextMnemonic: mnemonic?.plaintextMnemonic,
       hdEnabled: options.derivationMethod == DerivationMethod.hdWallet,
+      allowWeakPassword: options.allowWeakPassword,
     );
 
     return _lockWriteOperation(() async {

--- a/packages/komodo_defi_local_auth/lib/src/auth/auth_service_kdf_extension.dart
+++ b/packages/komodo_defi_local_auth/lib/src/auth/auth_service_kdf_extension.dart
@@ -169,6 +169,7 @@ extension KdfExtensions on KdfAuthService {
     required bool hdEnabled,
     String? plaintextMnemonic,
     String? encryptedMnemonic,
+    bool allowWeakPassword = false,
   }) async {
     if (plaintextMnemonic != null && encryptedMnemonic != null) {
       throw AuthException(
@@ -184,6 +185,7 @@ extension KdfExtensions on KdfAuthService {
       rpcPassword: _hostConfig.rpcPassword,
       allowRegistrations: allowRegistrations,
       enableHd: hdEnabled,
+      allowWeakPassword: allowWeakPassword,
     );
   }
 }

--- a/packages/komodo_defi_types/lib/src/auth/auth_options.dart
+++ b/packages/komodo_defi_types/lib/src/auth/auth_options.dart
@@ -5,23 +5,27 @@ import 'package:komodo_defi_types/komodo_defi_types.dart';
 class AuthOptions extends Equatable {
   const AuthOptions({
     required this.derivationMethod,
+    this.allowWeakPassword = false,
   });
 
   factory AuthOptions.fromJson(JsonMap json) {
     return AuthOptions(
       derivationMethod:
           DerivationMethod.parse(json.value<String>('derivation_method')),
+      allowWeakPassword: json.valueOrNull<bool>('allow_weak_password') ?? false,
     );
   }
 
   final DerivationMethod derivationMethod;
+  final bool allowWeakPassword;
 
   JsonMap toJson() {
     return {
       'derivation_method': derivationMethod.toString(),
+      'allow_weak_password': allowWeakPassword,
     };
   }
-  
+
   @override
-  List<Object?> get props => [derivationMethod];
+  List<Object?> get props => [derivationMethod, allowWeakPassword];
 }


### PR DESCRIPTION
Adds a boolean flag to the `AuthOptions` class to allow users of the SDK to control the `allow_weak_passwords` KDF field if desired (support, debugging, etc).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for allowing weak passwords during authentication and registration, configurable via a new option in authentication settings.

- **Bug Fixes**
  - Ensured that the new weak password option is properly handled during wallet startup configuration.

- **Documentation**
  - Updated JSON serialization and equality checks to include the new weak password setting in authentication options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->