### PR TITLE
fix: breaking tendermint config changes and build transformer not using branch-specific content URL for non-master branches

### DIFF
--- a/packages/komodo_coins/lib/src/komodo_coins_base.dart
+++ b/packages/komodo_coins/lib/src/komodo_coins_base.dart
@@ -39,7 +39,7 @@ class KomodoCoins {
     final url = Uri.parse(
       'https://komodoplatform.github.io/coins/utils/coins_config_unfiltered.json',
     );
-  
+
     try {
       final response = await http.get(url);
       if (response.statusCode != 200) {
@@ -132,5 +132,14 @@ class KomodoCoins {
         .where((e) => e.key.isChildAsset && e.key.parentId == parentId)
         .map((e) => e.value)
         .toSet();
+  }
+
+  static Future<JsonList> fetchAndTransformCoinsList() async {
+    const coinsUrl = 'https://komodoplatform.github.io/coins/coins';
+
+    final coins =
+        jsonListFromString((await http.get(Uri.parse(coinsUrl))).body);
+
+    return coins.applyTransforms;
   }
 }

--- a/packages/komodo_coins/lib/src/komodo_coins_base.dart
+++ b/packages/komodo_coins/lib/src/komodo_coins_base.dart
@@ -33,7 +33,6 @@ class KomodoCoins {
   }
 
   Future<Map<AssetId, Asset>> fetchAssets() async {
-    
     if (_assets != null) return _assets!;
 
     final url = Uri.parse(
@@ -137,9 +136,21 @@ class KomodoCoins {
   static Future<JsonList> fetchAndTransformCoinsList() async {
     const coinsUrl = 'https://komodoplatform.github.io/coins/coins';
 
-    final coins =
-        jsonListFromString((await http.get(Uri.parse(coinsUrl))).body);
+    try {
+      final response = await http.get(Uri.parse(coinsUrl));
 
-    return coins.applyTransforms;
+      if (response.statusCode != 200) {
+        throw HttpException(
+          'Failed to fetch coins list. Status code: ${response.statusCode}',
+          uri: Uri.parse(coinsUrl),
+        );
+      }
+
+      final coins = jsonListFromString(response.body);
+      return coins.applyTransforms;
+    } catch (e) {
+      debugPrint('Error fetching and transforming coins list: $e');
+      throw Exception('Failed to fetch or process coins list: $e');
+    }
   }
 }

--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -63,7 +63,7 @@
     "coins": {
         "fetch_at_build_enabled": true,
         "update_commit_on_build": true,
-        "bundled_coins_repo_commit": "45b5764e872f026a85905e343fecb92ca72236bb",
+        "bundled_coins_repo_commit": "cbbfe2dc83a8c5f037bcbef21737acd86b85b543",
         "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",
         "coins_repo_content_url": "https://komodoplatform.github.io/coins",
         "coins_repo_branch": "master",

--- a/packages/komodo_defi_framework/lib/src/config/kdf_startup_config.dart
+++ b/packages/komodo_defi_framework/lib/src/config/kdf_startup_config.dart
@@ -8,6 +8,7 @@ import 'package:http/http.dart' as http;
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
+import 'package:komodo_coins/komodo_coins.dart';
 
 class KdfStartupConfig {
   KdfStartupConfig._({
@@ -191,13 +192,10 @@ class KdfStartupConfig {
   //       'mm2': 1,
   //     };
 
-  static const coinsUrl = 'https://komodoplatform.github.io/coins/coins';
-
   static Future<JsonList> _fetchCoinsData() async {
     if (_memoizedCoins != null) return _memoizedCoins!;
 
-    return _memoizedCoins =
-        jsonListFromString((await http.get(Uri.parse(coinsUrl))).body);
+    return _memoizedCoins = await KomodoCoins.fetchAndTransformCoinsList();
 
     // TODO: Implement getting from local asset as a fallback
     // final coinsDataAssetOrEmpty = await rootBundle

--- a/packages/komodo_defi_framework/pubspec.yaml
+++ b/packages/komodo_defi_framework/pubspec.yaml
@@ -20,6 +20,8 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   http: ^1.2.2
+  komodo_coins:
+    path: ../komodo_coins
   komodo_defi_types:
     path: ../komodo_defi_types
   komodo_wallet_build_transformer:

--- a/packages/komodo_defi_sdk/lib/src/activation/protocol_strategies/tendermint_activation_strategy.dart
+++ b/packages/komodo_defi_sdk/lib/src/activation/protocol_strategies/tendermint_activation_strategy.dart
@@ -47,7 +47,7 @@ class TendermintActivationStrategy extends ProtocolActivationStrategy {
           stepCount: 4,
           additionalInfo: {
             'rpcEndpoints': protocol.rpcUrlsMap.length,
-            'chainId': protocol.chainId,
+            if (protocol.chainId != null) 'chainId': protocol.chainId,
           },
         ),
       );
@@ -98,7 +98,7 @@ class TendermintActivationStrategy extends ProtocolActivationStrategy {
           additionalInfo: {
             'activatedChain': asset.id.name,
             'activationTime': DateTime.now().toIso8601String(),
-            'chainId': protocol.chainId,
+            if (protocol.chainId != null) 'chainId': protocol.chainId,
             'accountPrefix': protocol.accountPrefix,
           },
         ),

--- a/packages/komodo_defi_types/lib/src/protocols/erc20/erc20_protocol.dart
+++ b/packages/komodo_defi_types/lib/src/protocols/erc20/erc20_protocol.dart
@@ -38,7 +38,6 @@ class Erc20Protocol extends ProtocolClass {
 
   static void _validateErc20Config(JsonMap json) {
     final requiredFields = {
-      'chain_id': 'Chain ID',
       'nodes': 'RPC nodes',
       'swap_contract_address': 'Swap contract',
       'fallback_swap_contract': 'Fallback swap contract',
@@ -53,8 +52,6 @@ class Erc20Protocol extends ProtocolClass {
       }
     }
   }
-
-  int get chainId => config.value<int>('chain_id');
 
   List<EvmNode> get nodes =>
       config.value<JsonList>('nodes').map(EvmNode.fromJson).toList();

--- a/packages/komodo_defi_types/lib/src/protocols/tendermint/tendermint_protocol.dart
+++ b/packages/komodo_defi_types/lib/src/protocols/tendermint/tendermint_protocol.dart
@@ -41,8 +41,8 @@ class TendermintProtocol extends ProtocolClass {
 
   String? get accountPrefix => config.valueOrNull<String>('account_prefix');
 
-  String get chainId =>
-      config.value<String>('protocol', 'protocol_data', 'chain_id');
+  String? get chainId =>
+      config.valueOrNull<String>('protocol', 'protocol_data', 'chain_id');
 
   @override
   bool get supportsMultipleAddresses => false;

--- a/packages/komodo_wallet_build_transformer/lib/src/steps/models/coin_assets/coin_build_config.dart
+++ b/packages/komodo_wallet_build_transformer/lib/src/steps/models/coin_assets/coin_build_config.dart
@@ -45,6 +45,15 @@ class CoinBuildConfig {
     );
   }
 
+  bool get isMainBranch =>
+      coinsRepoBranch == 'master' || coinsRepoBranch == 'main';
+
+  String get rawContentUrl =>
+      'https://raw.githubusercontent.com/KomodoPlatform/coins/refs/heads/$coinsRepoBranch';
+
+  static const String cdnContentUrl =
+      'https://api.github.com/repos/KomodoPlatform/coins';
+
   /// Indicates whether fetching updates of the coins assets are enabled.
   final bool fetchAtBuildEnabled;
 
@@ -119,17 +128,17 @@ class CoinBuildConfig {
 
   /// Converts the [CoinBuildConfig] instance to a JSON object.
   Map<String, dynamic> toJson() => <String, dynamic>{
-        'fetch_at_build_enabled': fetchAtBuildEnabled,
-        'update_commit_on_build': updateCommitOnBuild,
-        'bundled_coins_repo_commit': bundledCoinsRepoCommit,
-        'coins_repo_api_url': coinsRepoApiUrl,
-        'coins_repo_content_url': coinsRepoContentUrl,
-        'coins_repo_branch': coinsRepoBranch,
-        'runtime_updates_enabled': runtimeUpdatesEnabled,
-        'mapped_files': mappedFiles,
-        'mapped_folders': mappedFolders,
-        'concurrent_downloads_enabled': concurrentDownloadsEnabled,
-      };
+    'fetch_at_build_enabled': fetchAtBuildEnabled,
+    'update_commit_on_build': updateCommitOnBuild,
+    'bundled_coins_repo_commit': bundledCoinsRepoCommit,
+    'coins_repo_api_url': coinsRepoApiUrl,
+    'coins_repo_content_url': coinsRepoContentUrl,
+    'coins_repo_branch': coinsRepoBranch,
+    'runtime_updates_enabled': runtimeUpdatesEnabled,
+    'mapped_files': mappedFiles,
+    'mapped_folders': mappedFolders,
+    'concurrent_downloads_enabled': concurrentDownloadsEnabled,
+  };
 
   /// Loads the coins runtime update configuration synchronously from the
   /// specified [path].
@@ -170,13 +179,11 @@ class CoinBuildConfig {
     required String assetPath,
     BuildConfig? originalBuildConfig,
   }) async {
-    final foldersToCreate = <String>[
-      path.dirname(assetPath),
-    ];
+    final foldersToCreate = <String>[path.dirname(assetPath)];
     createFolders(foldersToCreate);
 
-    final mergedConfig = (originalBuildConfig?.toJson() ?? {})
-      ..addAll({'coins': toJson()});
+    final mergedConfig =
+        (originalBuildConfig?.toJson() ?? {})..addAll({'coins': toJson()});
 
     print('Saving coin assets config to $assetPath');
     const encoder = JsonEncoder.withIndent('    ');


### PR DESCRIPTION
## Changes 

- Use the raw github content API rather than the CDN URL for non-master/non-main coins repo branches
- Remove `chainId` from ERC20 and Tendermint validation functions
- Temporarily remove the `protocol_data` field for "ETH" type coins in the coins file during the transition for the breaking IBC changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added batch transformation and filtering for coin configuration lists, including automatic cleanup of Ethereum protocol data.
  - Introduced a method to fetch and transform the latest coin list from a remote source.

- **Bug Fixes**
  - Improved handling of missing or optional chain IDs in protocol configurations to prevent errors.

- **Refactor**
  - Delegated coin list fetching and transformation to a shared package for consistency and maintainability.
  - Enhanced configuration classes with new accessors for branch and URL management.

- **Style**
  - Improved code formatting and readability in several modules.
  - Added logging enhancements for better traceability during file downloads.

- **Chores**
  - Updated build configuration with the latest coin repository commit.
  - Added a new package dependency for coin data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->