### PR TITLE
Add swap manager with example UI

### DIFF
--- a/Fetching
+++ b/Fetching
@@ -1,0 +1,3 @@
+
+# Bloc and Commit Conventions
+ documentation...

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/active_swaps.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/active_swaps.dart
@@ -1,0 +1,37 @@
+import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+class ActiveSwapsRequest
+    extends BaseRequest<ActiveSwapsResponse, GeneralErrorResponse>
+    with RequestHandlingMixin {
+  ActiveSwapsRequest({required super.rpcPass})
+    : super(method: 'active_swaps', mmrpc: '2.0');
+
+  @override
+  Map<String, dynamic> toJson() => super.toJson();
+
+  @override
+  ActiveSwapsResponse parse(Map<String, dynamic> json) =>
+      ActiveSwapsResponse.parse(json);
+}
+
+class ActiveSwapsResponse extends BaseResponse {
+  ActiveSwapsResponse({required super.mmrpc, required this.swaps});
+
+  factory ActiveSwapsResponse.parse(Map<String, dynamic> json) =>
+      ActiveSwapsResponse(
+        mmrpc: json.value<String>('mmrpc'),
+        swaps:
+            (json.value<JsonList>('result') as List)
+                .map((e) => SwapStatus.fromJson(e))
+                .toList(),
+      );
+
+  final List<SwapStatus> swaps;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'mmrpc': mmrpc,
+    'swaps': swaps.map((e) => e.toJson()).toList(),
+  };
+}

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/buy.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/buy.dart
@@ -1,0 +1,27 @@
+import 'package:decimal/decimal.dart';
+import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+class BuyRequest extends BaseRequest<BuySellResponse, GeneralErrorResponse>
+    with RequestHandlingMixin {
+  BuyRequest({
+    required super.rpcPass,
+    required this.base,
+    required this.rel,
+    required this.volume,
+  }) : super(method: 'buy', mmrpc: '2.0');
+
+  final String base;
+  final String rel;
+  final Decimal volume;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    ...super.toJson(),
+    'params': {'base': base, 'rel': rel, 'volume': volume.toString()},
+  };
+
+  @override
+  BuySellResponse parse(Map<String, dynamic> json) =>
+      BuySellResponse.parse(json);
+}

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/buy_sell_response.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/buy_sell_response.dart
@@ -1,0 +1,16 @@
+import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+class BuySellResponse extends BaseResponse {
+  BuySellResponse({required super.mmrpc, required this.result});
+
+  factory BuySellResponse.parse(Map<String, dynamic> json) => BuySellResponse(
+    mmrpc: json.value<String>('mmrpc'),
+    result: BuySellResult.fromJson(json.value<JsonMap>('result')),
+  );
+
+  final BuySellResult result;
+
+  @override
+  Map<String, dynamic> toJson() => {'mmrpc': mmrpc, 'result': result.toJson()};
+}

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/my_recent_swaps.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/my_recent_swaps.dart
@@ -1,0 +1,43 @@
+import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+class MyRecentSwapsRequest
+    extends BaseRequest<MyRecentSwapsResponse, GeneralErrorResponse>
+    with RequestHandlingMixin {
+  MyRecentSwapsRequest({required super.rpcPass, this.limit})
+    : super(method: 'my_recent_swaps', mmrpc: '2.0');
+
+  final int? limit;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    ...super.toJson(),
+    'params': {if (limit != null) 'limit': limit},
+  };
+
+  @override
+  MyRecentSwapsResponse parse(Map<String, dynamic> json) =>
+      MyRecentSwapsResponse.parse(json);
+}
+
+class MyRecentSwapsResponse extends BaseResponse {
+  MyRecentSwapsResponse({required super.mmrpc, required this.swaps});
+
+  factory MyRecentSwapsResponse.parse(Map<String, dynamic> json) =>
+      MyRecentSwapsResponse(
+        mmrpc: json.value<String>('mmrpc'),
+        swaps:
+            (json.value<JsonList>(
+              'result',
+              'swaps',
+            )).map((e) => SwapStatus.fromJson(e)).toList(),
+      );
+
+  final List<SwapStatus> swaps;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'mmrpc': mmrpc,
+    'swaps': swaps.map((e) => e.toJson()).toList(),
+  };
+}

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/my_swap_status.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/my_swap_status.dart
@@ -1,0 +1,36 @@
+import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+class MySwapStatusRequest
+    extends BaseRequest<MySwapStatusResponse, GeneralErrorResponse>
+    with RequestHandlingMixin {
+  MySwapStatusRequest({required super.rpcPass, required this.uuid})
+    : super(method: 'my_swap_status', mmrpc: '2.0');
+
+  final String uuid;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    ...super.toJson(),
+    'params': {'uuid': uuid},
+  };
+
+  @override
+  MySwapStatusResponse parse(Map<String, dynamic> json) =>
+      MySwapStatusResponse.parse(json);
+}
+
+class MySwapStatusResponse extends BaseResponse {
+  MySwapStatusResponse({required super.mmrpc, required this.swap});
+
+  factory MySwapStatusResponse.parse(Map<String, dynamic> json) =>
+      MySwapStatusResponse(
+        mmrpc: json.value<String>('mmrpc'),
+        swap: SwapStatus.fromJson(json.value<JsonMap>('result')),
+      );
+
+  final SwapStatus swap;
+
+  @override
+  Map<String, dynamic> toJson() => {'mmrpc': mmrpc, 'result': swap.toJson()};
+}

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/one_inch_v6_create.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/one_inch_v6_create.dart
@@ -1,0 +1,112 @@
+import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+class OneInchV6ClassicSwapCreateRequest
+    extends
+        BaseRequest<OneInchV6ClassicSwapCreateResponse, GeneralErrorResponse>
+    with RequestHandlingMixin {
+  OneInchV6ClassicSwapCreateRequest({
+    required super.rpcPass,
+    required this.base,
+    required this.rel,
+    required this.amount,
+    required this.slippage,
+    this.fee,
+    this.protocols,
+    this.gasPrice,
+    this.complexityLevel,
+    this.parts,
+    this.mainRouteParts,
+    this.gasLimit,
+    this.includeTokensInfo,
+    this.includeProtocols,
+    this.includeGas,
+    this.connectorTokens,
+    this.excludedProtocols,
+    this.permit,
+    this.compatibility,
+    this.receiver,
+    this.referrer,
+    this.disableEstimate,
+    this.allowPartialFill,
+    this.usePermit2,
+  }) : super(method: '1inch_v6_0_classic_swap_create', mmrpc: '2.0');
+
+  final String base;
+  final String rel;
+  final num amount;
+  final num slippage;
+  final num? fee;
+  final String? protocols;
+  final String? gasPrice;
+  final int? complexityLevel;
+  final int? parts;
+  final int? mainRouteParts;
+  final int? gasLimit;
+  final bool? includeTokensInfo;
+  final bool? includeProtocols;
+  final bool? includeGas;
+  final String? connectorTokens;
+  final String? excludedProtocols;
+  final String? permit;
+  final bool? compatibility;
+  final String? receiver;
+  final String? referrer;
+  final bool? disableEstimate;
+  final bool? allowPartialFill;
+  final bool? usePermit2;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    ...super.toJson(),
+    'params': {
+      'base': base,
+      'rel': rel,
+      'amount': amount,
+      'slippage': slippage,
+      if (fee != null) 'fee': fee,
+      if (protocols != null) 'protocols': protocols,
+      if (gasPrice != null) 'gas_price': gasPrice,
+      if (complexityLevel != null) 'complexity_level': complexityLevel,
+      if (parts != null) 'parts': parts,
+      if (mainRouteParts != null) 'main_route_parts': mainRouteParts,
+      if (gasLimit != null) 'gas_limit': gasLimit,
+      if (includeTokensInfo != null) 'include_tokens_info': includeTokensInfo,
+      if (includeProtocols != null) 'include_protocols': includeProtocols,
+      if (includeGas != null) 'include_gas': includeGas,
+      if (connectorTokens != null) 'connector_tokens': connectorTokens,
+      if (excludedProtocols != null) 'excluded_protocols': excludedProtocols,
+      if (permit != null) 'permit': permit,
+      if (compatibility != null) 'compatibility': compatibility,
+      if (receiver != null) 'receiver': receiver,
+      if (referrer != null) 'referrer': referrer,
+      if (disableEstimate != null) 'disable_estimate': disableEstimate,
+      if (allowPartialFill != null) 'allow_partial_fill': allowPartialFill,
+      if (usePermit2 != null) 'use_permit2': usePermit2,
+    },
+  };
+
+  @override
+  OneInchV6ClassicSwapCreateResponse parse(Map<String, dynamic> json) =>
+      OneInchV6ClassicSwapCreateResponse.parse(json);
+}
+
+class OneInchV6ClassicSwapCreateResponse extends BaseResponse {
+  OneInchV6ClassicSwapCreateResponse({
+    required super.mmrpc,
+    required this.result,
+  });
+
+  factory OneInchV6ClassicSwapCreateResponse.parse(Map<String, dynamic> json) =>
+      OneInchV6ClassicSwapCreateResponse(
+        mmrpc: json.value<String>('mmrpc'),
+        result: OneInchClassicSwapCreate.fromJson(
+          json.value<JsonMap>('result'),
+        ),
+      );
+
+  final OneInchClassicSwapCreate result;
+
+  @override
+  Map<String, dynamic> toJson() => {'mmrpc': mmrpc, 'result': result.toJson()};
+}

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/one_inch_v6_liquidity_sources.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/one_inch_v6_liquidity_sources.dart
@@ -1,0 +1,49 @@
+import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+class OneInchV6ClassicSwapLiquiditySourcesRequest
+    extends
+        BaseRequest<
+          OneInchV6ClassicSwapLiquiditySourcesResponse,
+          GeneralErrorResponse
+        >
+    with RequestHandlingMixin {
+  OneInchV6ClassicSwapLiquiditySourcesRequest({
+    required super.rpcPass,
+    required this.chainId,
+  }) : super(method: '1inch_v6_0_classic_swap_liquidity_sources', mmrpc: '2.0');
+
+  final int chainId;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    ...super.toJson(),
+    'params': {'chain_id': chainId},
+  };
+
+  @override
+  OneInchV6ClassicSwapLiquiditySourcesResponse parse(
+    Map<String, dynamic> json,
+  ) => OneInchV6ClassicSwapLiquiditySourcesResponse.parse(json);
+}
+
+class OneInchV6ClassicSwapLiquiditySourcesResponse extends BaseResponse {
+  OneInchV6ClassicSwapLiquiditySourcesResponse({
+    required super.mmrpc,
+    required this.result,
+  });
+
+  factory OneInchV6ClassicSwapLiquiditySourcesResponse.parse(
+    Map<String, dynamic> json,
+  ) => OneInchV6ClassicSwapLiquiditySourcesResponse(
+    mmrpc: json.value<String>('mmrpc'),
+    result: OneInchClassicLiquiditySources.fromJson(
+      json.value<JsonMap>('result'),
+    ),
+  );
+
+  final OneInchClassicLiquiditySources result;
+
+  @override
+  Map<String, dynamic> toJson() => {'mmrpc': mmrpc, 'result': result.toJson()};
+}

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/one_inch_v6_quote.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/one_inch_v6_quote.dart
@@ -1,0 +1,82 @@
+import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+class OneInchV6ClassicSwapQuoteRequest
+    extends BaseRequest<OneInchV6ClassicSwapQuoteResponse, GeneralErrorResponse>
+    with RequestHandlingMixin {
+  OneInchV6ClassicSwapQuoteRequest({
+    required super.rpcPass,
+    required this.base,
+    required this.rel,
+    required this.amount,
+    this.fee,
+    this.protocols,
+    this.gasPrice,
+    this.complexityLevel,
+    this.parts,
+    this.mainRouteParts,
+    this.gasLimit,
+    this.includeTokensInfo,
+    this.includeProtocols,
+    this.includeGas,
+    this.connectorTokens,
+  }) : super(method: '1inch_v6_0_classic_swap_quote', mmrpc: '2.0');
+
+  final String base;
+  final String rel;
+  final num amount;
+  final num? fee;
+  final String? protocols;
+  final String? gasPrice;
+  final int? complexityLevel;
+  final int? parts;
+  final int? mainRouteParts;
+  final int? gasLimit;
+  final bool? includeTokensInfo;
+  final bool? includeProtocols;
+  final bool? includeGas;
+  final String? connectorTokens;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    ...super.toJson(),
+    'params': {
+      'base': base,
+      'rel': rel,
+      'amount': amount,
+      if (fee != null) 'fee': fee,
+      if (protocols != null) 'protocols': protocols,
+      if (gasPrice != null) 'gas_price': gasPrice,
+      if (complexityLevel != null) 'complexity_level': complexityLevel,
+      if (parts != null) 'parts': parts,
+      if (mainRouteParts != null) 'main_route_parts': mainRouteParts,
+      if (gasLimit != null) 'gas_limit': gasLimit,
+      if (includeTokensInfo != null) 'include_tokens_info': includeTokensInfo,
+      if (includeProtocols != null) 'include_protocols': includeProtocols,
+      if (includeGas != null) 'include_gas': includeGas,
+      if (connectorTokens != null) 'connector_tokens': connectorTokens,
+    },
+  };
+
+  @override
+  OneInchV6ClassicSwapQuoteResponse parse(Map<String, dynamic> json) =>
+      OneInchV6ClassicSwapQuoteResponse.parse(json);
+}
+
+class OneInchV6ClassicSwapQuoteResponse extends BaseResponse {
+  OneInchV6ClassicSwapQuoteResponse({
+    required super.mmrpc,
+    required this.result,
+  });
+
+  factory OneInchV6ClassicSwapQuoteResponse.parse(Map<String, dynamic> json) =>
+      OneInchV6ClassicSwapQuoteResponse(
+        mmrpc: json.value<String>('mmrpc'),
+        result: OneInchClassicSwapQuote.fromJson(json.value<JsonMap>('result')),
+      );
+
+  final OneInchClassicSwapQuote result;
+
+  @override
+  Map<String, dynamic> toJson() => {'mmrpc': mmrpc, 'result': result.toJson()};
+}

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/one_inch_v6_tokens.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/one_inch_v6_tokens.dart
@@ -1,0 +1,44 @@
+import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+class OneInchV6ClassicSwapTokensRequest
+    extends
+        BaseRequest<OneInchV6ClassicSwapTokensResponse, GeneralErrorResponse>
+    with RequestHandlingMixin {
+  OneInchV6ClassicSwapTokensRequest({
+    required super.rpcPass,
+    required this.chainId,
+  }) : super(method: '1inch_v6_0_classic_swap_tokens', mmrpc: '2.0');
+
+  final int chainId;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    ...super.toJson(),
+    'params': {'chain_id': chainId},
+  };
+
+  @override
+  OneInchV6ClassicSwapTokensResponse parse(Map<String, dynamic> json) =>
+      OneInchV6ClassicSwapTokensResponse.parse(json);
+}
+
+class OneInchV6ClassicSwapTokensResponse extends BaseResponse {
+  OneInchV6ClassicSwapTokensResponse({
+    required super.mmrpc,
+    required this.result,
+  });
+
+  factory OneInchV6ClassicSwapTokensResponse.parse(Map<String, dynamic> json) =>
+      OneInchV6ClassicSwapTokensResponse(
+        mmrpc: json.value<String>('mmrpc'),
+        result: OneInchClassicSwapTokens.fromJson(
+          json.value<JsonMap>('result'),
+        ),
+      );
+
+  final OneInchClassicSwapTokens result;
+
+  @override
+  Map<String, dynamic> toJson() => {'mmrpc': mmrpc, 'result': result.toJson()};
+}

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/sell.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/sell.dart
@@ -1,0 +1,27 @@
+import 'package:decimal/decimal.dart';
+import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+class SellRequest extends BaseRequest<BuySellResponse, GeneralErrorResponse>
+    with RequestHandlingMixin {
+  SellRequest({
+    required super.rpcPass,
+    required this.base,
+    required this.rel,
+    required this.volume,
+  }) : super(method: 'sell', mmrpc: '2.0');
+
+  final String base;
+  final String rel;
+  final Decimal volume;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    ...super.toJson(),
+    'params': {'base': base, 'rel': rel, 'volume': volume.toString()},
+  };
+
+  @override
+  BuySellResponse parse(Map<String, dynamic> json) =>
+      BuySellResponse.parse(json);
+}

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/swap_rpc_namespace.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/swap/swap_rpc_namespace.dart
@@ -1,0 +1,47 @@
+import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+import 'active_swaps.dart';
+import 'buy.dart';
+import 'buy_sell_response.dart';
+import 'my_recent_swaps.dart';
+import 'my_swap_status.dart';
+import 'sell.dart';
+
+class SwapMethodsNamespace extends BaseRpcMethodNamespace {
+  SwapMethodsNamespace(super.client);
+
+  Future<OneInchV6ClassicSwapQuoteResponse> oneInchClassicQuote(
+    OneInchV6ClassicSwapQuoteRequest request,
+  ) => execute(request);
+
+  Future<OneInchV6ClassicSwapCreateResponse> oneInchClassicCreate(
+    OneInchV6ClassicSwapCreateRequest request,
+  ) => execute(request);
+
+  Future<OneInchV6ClassicSwapTokensResponse> oneInchClassicTokens(
+    int chainId,
+  ) => execute(
+    OneInchV6ClassicSwapTokensRequest(rpcPass: rpcPass ?? '', chainId: chainId),
+  );
+
+  Future<OneInchV6ClassicSwapLiquiditySourcesResponse>
+  oneInchClassicLiquiditySources(int chainId) => execute(
+    OneInchV6ClassicSwapLiquiditySourcesRequest(
+      rpcPass: rpcPass ?? '',
+      chainId: chainId,
+    ),
+  );
+
+  Future<BuySellResponse> buy(BuyRequest request) => execute(request);
+
+  Future<BuySellResponse> sell(SellRequest request) => execute(request);
+
+  Future<MyRecentSwapsResponse> myRecentSwaps({int? limit}) =>
+      execute(MyRecentSwapsRequest(rpcPass: rpcPass ?? '', limit: limit));
+
+  Future<MySwapStatusResponse> mySwapStatus(String uuid) =>
+      execute(MySwapStatusRequest(rpcPass: rpcPass ?? '', uuid: uuid));
+
+  Future<ActiveSwapsResponse> activeSwaps() =>
+      execute(ActiveSwapsRequest(rpcPass: rpcPass ?? ''));
+}

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods_library.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods_library.dart
@@ -5,6 +5,7 @@
 
 import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
+import 'rpc_methods/swap/swap_rpc_namespace.dart';
 
 /// A class that provides a library of RPC methods used by the Komodo DeFi
 /// Framework API. This class is used to group RPC methods together and provide
@@ -43,6 +44,7 @@ class KomodoDefiRpcMethods {
 
   // Add other namespaces here, e.g.:
   // TradeNamespace get trade => TradeNamespace(_client);
+  SwapMethodsNamespace get swap => SwapMethodsNamespace(_client);
   MessageSigningMethodsNamespace get messageSigning =>
       MessageSigningMethodsNamespace(_client);
   UtilityMethods get utility => UtilityMethods(_client);

--- a/packages/komodo_defi_sdk/example/lib/screens/asset_page.dart
+++ b/packages/komodo_defi_sdk/example/lib/screens/asset_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kdf_sdk_example/screens/withdrawal_page.dart';
+import 'package:kdf_sdk_example/screens/swap_page.dart';
 import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
@@ -348,6 +349,18 @@ class _AssetHeaderState extends State<AssetHeader> {
                   },
           icon: const Icon(Icons.send),
           label: const Text('Send'),
+        ),
+        FilledButton.icon(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute<void>(
+                builder: (context) => SwapPage(widget.asset),
+              ),
+            );
+          },
+          icon: const Icon(Icons.currency_exchange),
+          label: const Text('Swap'),
         ),
         FilledButton.tonalIcon(
           onPressed: () {},

--- a/packages/komodo_defi_sdk/example/lib/screens/swap_page.dart
+++ b/packages/komodo_defi_sdk/example/lib/screens/swap_page.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+
+import 'package:decimal/decimal.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+class SwapPage extends StatefulWidget {
+  const SwapPage(this.asset, {super.key});
+
+  final Asset asset;
+
+  @override
+  State<SwapPage> createState() => _SwapPageState();
+}
+
+class _SwapPageState extends State<SwapPage> {
+  final _relController = TextEditingController();
+  final _amountController = TextEditingController();
+  StreamSubscription<SwapStatus>? _subscription;
+  SwapStatus? _status;
+  OneInchClassicSwapQuote? _quote;
+  bool _loading = false;
+
+  KomodoDefiSdk get _sdk => context.read<KomodoDefiSdk>();
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    _relController.dispose();
+    _amountController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _getQuote() async {
+    setState(() => _loading = true);
+    try {
+      final amount = Decimal.parse(_amountController.text);
+      final quote = await _sdk.swaps.getClassicQuote(
+        base: widget.asset.id.id,
+        rel: _relController.text,
+        amount: amount,
+      );
+      setState(() => _quote = quote);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Quote error: $e')));
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _startSwap() async {
+    setState(() {
+      _status = null;
+      _loading = true;
+    });
+    final amount = Decimal.parse(_amountController.text);
+    _subscription = _sdk.swaps
+        .buy(base: widget.asset.id.id, rel: _relController.text, volume: amount)
+        .listen(
+          (status) {
+            setState(() {
+              _status = status;
+              _loading = false;
+            });
+          },
+          onError: (e) {
+            setState(() => _loading = false);
+            ScaffoldMessenger.of(
+              context,
+            ).showSnackBar(SnackBar(content: Text('Swap error: $e')));
+          },
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Swap ${widget.asset.id.id}')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _relController,
+              decoration: const InputDecoration(labelText: 'Rel asset'),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _amountController,
+              decoration: const InputDecoration(labelText: 'Amount'),
+              keyboardType: TextInputType.number,
+            ),
+            const SizedBox(height: 16),
+            if (_loading) const LinearProgressIndicator(),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                ElevatedButton(
+                  onPressed: _loading ? null : _getQuote,
+                  child: const Text('Get Quote'),
+                ),
+                const SizedBox(width: 16),
+                ElevatedButton(
+                  onPressed: _loading ? null : _startSwap,
+                  child: const Text('Start Swap'),
+                ),
+              ],
+            ),
+            if (_quote != null) ...[
+              const SizedBox(height: 16),
+              Text('Quote: ${_quote!.dstAmount} ${_relController.text}'),
+            ],
+            if (_status != null) ...[
+              const SizedBox(height: 16),
+              Text('Status: ${_status!.events.last.type}'),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/komodo_defi_sdk/lib/src/_internal_exports.dart
+++ b/packages/komodo_defi_sdk/lib/src/_internal_exports.dart
@@ -6,3 +6,4 @@ library _internal_exports;
 export 'activation/_activation_index.dart';
 export 'assets/_assets_index.dart';
 export 'transaction_history/_transaction_history_index.dart';
+export 'swaps/_swaps_index.dart';

--- a/packages/komodo_defi_sdk/lib/src/bootstrap.dart
+++ b/packages/komodo_defi_sdk/lib/src/bootstrap.dart
@@ -197,6 +197,11 @@ Future<void> bootstrap({
     return WithdrawalManager(client, assetProvider, activationManager);
   }, dependsOn: [ApiClient, AssetManager, ActivationManager]);
 
+  container.registerSingletonAsync<SwapManager>(() async {
+    final client = await container.getAsync<ApiClient>();
+    return SwapManager(client);
+  }, dependsOn: [ApiClient]);
+
   // Wait for all async singletons to initialize
   await container.allReady();
 }

--- a/packages/komodo_defi_sdk/lib/src/komodo_defi_sdk.dart
+++ b/packages/komodo_defi_sdk/lib/src/komodo_defi_sdk.dart
@@ -9,6 +9,7 @@ import 'package:komodo_defi_sdk/src/message_signing/message_signing_manager.dart
 import 'package:komodo_defi_sdk/src/pubkeys/pubkey_manager.dart';
 import 'package:komodo_defi_sdk/src/storage/secure_rpc_password_mixin.dart';
 import 'package:komodo_defi_sdk/src/withdrawals/withdrawal_manager.dart';
+import 'package:komodo_defi_sdk/src/swaps/swap_manager.dart';
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 
@@ -222,6 +223,9 @@ class KomodoDefiSdk with SecureRpcPasswordMixin {
   /// Throws [StateError] if accessed before initialization.
   WithdrawalManager get withdrawals =>
       _assertSdkInitialized(_container<WithdrawalManager>());
+
+  /// The swap manager instance for handling atomic and 1inch swaps.
+  SwapManager get swaps => _assertSdkInitialized(_container<SwapManager>());
 
   /// The price manager instance.
   ///

--- a/packages/komodo_defi_sdk/lib/src/swaps/_swaps_index.dart
+++ b/packages/komodo_defi_sdk/lib/src/swaps/_swaps_index.dart
@@ -1,0 +1,4 @@
+// (Internal/private) Generated index for swap related classes.
+library _swaps;
+
+export 'swap_manager.dart';

--- a/packages/komodo_defi_sdk/lib/src/swaps/swap_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/swaps/swap_manager.dart
@@ -1,0 +1,124 @@
+import 'package:decimal/decimal.dart';
+import 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart';
+import 'package:komodo_defi_sdk/src/_internal_exports.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+/// Manager class for swap related functionality.
+class SwapManager {
+  SwapManager(this._client);
+
+  final ApiClient _client;
+
+  /// Fetch a quote for a classic 1inch swap.
+  Future<OneInchClassicSwapQuote> getClassicQuote({
+    required String base,
+    required String rel,
+    required num amount,
+    num? fee,
+  }) async {
+    final response = await _client.rpc.swap.oneInchClassicQuote(
+      OneInchV6ClassicSwapQuoteRequest(
+        rpcPass: _client.rpcPass ?? '',
+        base: base,
+        rel: rel,
+        amount: amount,
+        fee: fee,
+      ),
+    );
+    return response.result;
+  }
+
+  /// Create a classic 1inch swap transaction.
+  Future<OneInchClassicSwapCreate> createClassicSwap({
+    required String base,
+    required String rel,
+    required num amount,
+    required num slippage,
+  }) async {
+    final response = await _client.rpc.swap.oneInchClassicCreate(
+      OneInchV6ClassicSwapCreateRequest(
+        rpcPass: _client.rpcPass ?? '',
+        base: base,
+        rel: rel,
+        amount: amount,
+        slippage: slippage,
+      ),
+    );
+    return response.result;
+  }
+
+  /// Get available tokens for swaps on a given chain.
+  Future<Map<String, OneInchTokenInfo>> getClassicTokens(int chainId) async {
+    final response = await _client.rpc.swap.oneInchClassicTokens(chainId);
+    return response.result.tokens;
+  }
+
+  /// Get available liquidity sources for swaps on a given chain.
+  Future<List<OneInchProtocolImage>> getClassicLiquiditySources(
+    int chainId,
+  ) async {
+    final response = await _client.rpc.swap.oneInchClassicLiquiditySources(
+      chainId,
+    );
+    return response.result.protocols;
+  }
+
+  /// Initiate a buy swap using legacy RPC.
+  Stream<SwapStatus> buy({
+    required String base,
+    required String rel,
+    required Decimal volume,
+  }) async* {
+    final response = await _client.rpc.swap.buy(
+      BuyRequest(
+        rpcPass: _client.rpcPass ?? '',
+        base: base,
+        rel: rel,
+        volume: volume,
+      ),
+    );
+    yield* watchSwapStatus(response.result.uuid);
+  }
+
+  /// Initiate a sell swap using legacy RPC.
+  Stream<SwapStatus> sell({
+    required String base,
+    required String rel,
+    required Decimal volume,
+  }) async* {
+    final response = await _client.rpc.swap.sell(
+      SellRequest(
+        rpcPass: _client.rpcPass ?? '',
+        base: base,
+        rel: rel,
+        volume: volume,
+      ),
+    );
+    yield* watchSwapStatus(response.result.uuid);
+  }
+
+  /// Watch swap status updates for given [uuid].
+  Stream<SwapStatus> watchSwapStatus(
+    String uuid, {
+    Duration interval = const Duration(seconds: 5),
+  }) async* {
+    while (true) {
+      final status = (await _client.rpc.swap.mySwapStatus(uuid)).swap;
+      yield status;
+      if (status.isFinished) break;
+      await Future.delayed(interval);
+    }
+  }
+
+  /// Get list of active swaps.
+  Future<List<SwapStatus>> activeSwaps() async {
+    final response = await _client.rpc.swap.activeSwaps();
+    return response.swaps;
+  }
+
+  /// Get recent swap history.
+  Future<List<SwapStatus>> recentSwaps({int? limit}) async {
+    final response = await _client.rpc.swap.myRecentSwaps(limit: limit);
+    return response.swaps;
+  }
+}

--- a/packages/komodo_defi_types/lib/komodo_defi_type_utils.dart
+++ b/packages/komodo_defi_types/lib/komodo_defi_type_utils.dart
@@ -3,6 +3,7 @@
 /// Utilities for types used throughout the Komodo DeFi Framework ecosystem.
 library komodo_defi_type_utils;
 
+export 'src/utils/backoff_strategy.dart';
 export 'src/utils/iterable_type_utils.dart';
 export 'src/utils/json_type_utils.dart';
 export 'src/utils/live_data.dart';

--- a/packages/komodo_defi_types/lib/src/swaps/swap_types.dart
+++ b/packages/komodo_defi_types/lib/src/swaps/swap_types.dart
@@ -1,0 +1,370 @@
+import 'package:equatable/equatable.dart';
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+/// Information about a token returned from the 1inch API.
+class OneInchTokenInfo extends Equatable {
+  const OneInchTokenInfo({
+    required this.address,
+    required this.symbol,
+    required this.name,
+    required this.decimals,
+    required this.eip2612,
+    required this.isFoT,
+    required this.logoURI,
+    required this.tags,
+  });
+
+  factory OneInchTokenInfo.fromJson(JsonMap json) {
+    return OneInchTokenInfo(
+      address: json.value<String>('address'),
+      symbol: json.value<String>('symbol'),
+      name: json.value<String>('name'),
+      decimals: json.value<int>('decimals'),
+      eip2612: json.value<bool>('eip2612'),
+      isFoT: json.value<bool>('isFoT'),
+      logoURI: json.value<String>('logoURI'),
+      tags: List<String>.from(json.value<List>('tags')),
+    );
+  }
+
+  final String address;
+  final String symbol;
+  final String name;
+  final int decimals;
+  final bool eip2612;
+  final bool isFoT;
+  final String logoURI;
+  final List<String> tags;
+
+  JsonMap toJson() => {
+        'address': address,
+        'symbol': symbol,
+        'name': name,
+        'decimals': decimals,
+        'eip2612': eip2612,
+        'isFoT': isFoT,
+        'logoURI': logoURI,
+        'tags': tags,
+      };
+
+  @override
+  List<Object?> get props => [
+        address,
+        symbol,
+        name,
+        decimals,
+        eip2612,
+        isFoT,
+        logoURI,
+        tags,
+      ];
+}
+
+/// Information about a liquidity protocol used in a 1inch swap route.
+class OneInchProtocolInfo extends Equatable {
+  const OneInchProtocolInfo({
+    required this.name,
+    required this.part,
+    required this.fromTokenAddress,
+    required this.toTokenAddress,
+  });
+
+  factory OneInchProtocolInfo.fromJson(JsonMap json) => OneInchProtocolInfo(
+        name: json.value<String>('name'),
+        part: json.value<int>('part'),
+        fromTokenAddress: json.value<String>('fromTokenAddress'),
+        toTokenAddress: json.value<String>('toTokenAddress'),
+      );
+
+  final String name;
+  final int part;
+  final String fromTokenAddress;
+  final String toTokenAddress;
+
+  JsonMap toJson() => {
+        'name': name,
+        'part': part,
+        'fromTokenAddress': fromTokenAddress,
+        'toTokenAddress': toTokenAddress,
+      };
+
+  @override
+  List<Object?> get props => [name, part, fromTokenAddress, toTokenAddress];
+}
+
+/// Transaction fields returned from 1inch swap create.
+class OneInchTxFields extends Equatable {
+  const OneInchTxFields({
+    required this.from,
+    required this.to,
+    required this.data,
+    required this.value,
+    required this.gasPrice,
+    required this.gas,
+  });
+
+  factory OneInchTxFields.fromJson(JsonMap json) => OneInchTxFields(
+        from: json.value<String>('from'),
+        to: json.value<String>('to'),
+        data: json.value<String>('data'),
+        value: json.value<String>('value'),
+        gasPrice: json.value<num>('gas_price'),
+        gas: json.value<num>('gas'),
+      );
+
+  final String from;
+  final String to;
+  final String data;
+  final String value;
+  final num gasPrice;
+  final num gas;
+
+  JsonMap toJson() => {
+        'from': from,
+        'to': to,
+        'data': data,
+        'value': value,
+        'gas_price': gasPrice,
+        'gas': gas,
+      };
+
+  @override
+  List<Object?> get props => [from, to, data, value, gasPrice, gas];
+}
+
+/// Response model for 1inch classic swap quote.
+class OneInchClassicSwapQuote extends Equatable {
+  const OneInchClassicSwapQuote({
+    required this.dstAmount,
+    required this.srcToken,
+    required this.dstToken,
+    required this.protocols,
+    this.gas,
+  });
+
+  factory OneInchClassicSwapQuote.fromJson(JsonMap json) =>
+      OneInchClassicSwapQuote(
+        dstAmount: json.value<num>('dst_amount'),
+        srcToken: OneInchTokenInfo.fromJson(json.value<JsonMap>('src_token')),
+        dstToken: OneInchTokenInfo.fromJson(json.value<JsonMap>('dst_token')),
+        protocols: (json.value<List>('protocols') as List)
+            .expand((e) => (e as List))
+            .map((p) => OneInchProtocolInfo.fromJson(p))
+            .toList(),
+        gas: json.valueOrNull<num>('gas'),
+      );
+
+  final num dstAmount;
+  final OneInchTokenInfo srcToken;
+  final OneInchTokenInfo dstToken;
+  final List<OneInchProtocolInfo> protocols;
+  final num? gas;
+
+  JsonMap toJson() => {
+        'dst_amount': dstAmount,
+        'src_token': srcToken.toJson(),
+        'dst_token': dstToken.toJson(),
+        'protocols': protocols.map((e) => e.toJson()).toList(),
+        if (gas != null) 'gas': gas,
+      };
+
+  @override
+  List<Object?> get props => [dstAmount, srcToken, dstToken, protocols, gas];
+}
+
+/// Response model for 1inch classic swap create.
+class OneInchClassicSwapCreate extends Equatable {
+  const OneInchClassicSwapCreate({
+    required this.dstAmount,
+    required this.srcToken,
+    required this.dstToken,
+    required this.protocols,
+    required this.tx,
+  });
+
+  factory OneInchClassicSwapCreate.fromJson(JsonMap json) =>
+      OneInchClassicSwapCreate(
+        dstAmount: json.value<num>('dst_amount'),
+        srcToken: OneInchTokenInfo.fromJson(json.value<JsonMap>('src_token')),
+        dstToken: OneInchTokenInfo.fromJson(json.value<JsonMap>('dst_token')),
+        protocols: (json.value<List>('protocols') as List)
+            .expand((e) => (e as List))
+            .map((p) => OneInchProtocolInfo.fromJson(p))
+            .toList(),
+        tx: OneInchTxFields.fromJson(json.value<JsonMap>('tx')),
+      );
+
+  final num dstAmount;
+  final OneInchTokenInfo srcToken;
+  final OneInchTokenInfo dstToken;
+  final List<OneInchProtocolInfo> protocols;
+  final OneInchTxFields tx;
+
+  JsonMap toJson() => {
+        'dst_amount': dstAmount,
+        'src_token': srcToken.toJson(),
+        'dst_token': dstToken.toJson(),
+        'protocols': protocols.map((e) => e.toJson()).toList(),
+        'tx': tx.toJson(),
+      };
+
+  @override
+  List<Object?> get props => [dstAmount, srcToken, dstToken, protocols, tx];
+}
+
+/// Liquidity source image information.
+class OneInchProtocolImage extends Equatable {
+  const OneInchProtocolImage({
+    required this.id,
+    required this.title,
+    required this.img,
+    required this.imgColor,
+  });
+
+  factory OneInchProtocolImage.fromJson(JsonMap json) => OneInchProtocolImage(
+        id: json.value<String>('id'),
+        title: json.value<String>('title'),
+        img: json.value<String>('img'),
+        imgColor: json.value<String>('img_color'),
+      );
+
+  final String id;
+  final String title;
+  final String img;
+  final String imgColor;
+
+  JsonMap toJson() => {
+        'id': id,
+        'title': title,
+        'img': img,
+        'img_color': imgColor,
+      };
+
+  @override
+  List<Object?> get props => [id, title, img, imgColor];
+}
+
+/// Response model for liquidity sources.
+class OneInchClassicLiquiditySources extends Equatable {
+  const OneInchClassicLiquiditySources({required this.protocols});
+
+  factory OneInchClassicLiquiditySources.fromJson(JsonMap json) =>
+      OneInchClassicLiquiditySources(
+        protocols: (json.value<List>('protocols') as List)
+            .map((e) => OneInchProtocolImage.fromJson(e))
+            .toList(),
+      );
+
+  final List<OneInchProtocolImage> protocols;
+
+  JsonMap toJson() => {
+        'protocols': protocols.map((e) => e.toJson()).toList(),
+      };
+
+  @override
+  List<Object?> get props => [protocols];
+}
+
+/// Response model for swap tokens list.
+class OneInchClassicSwapTokens extends Equatable {
+  const OneInchClassicSwapTokens({required this.tokens});
+
+  factory OneInchClassicSwapTokens.fromJson(JsonMap json) =>
+      OneInchClassicSwapTokens(
+        tokens: (json.value<JsonMap>('tokens')).map(
+          (key, value) => MapEntry(
+            key.toString(),
+            OneInchTokenInfo.fromJson(value as JsonMap),
+          ),
+        ),
+      );
+
+  final Map<String, OneInchTokenInfo> tokens;
+
+  JsonMap toJson() => {
+        'tokens': tokens.map((k, v) => MapEntry(k, v.toJson())),
+      };
+
+  @override
+  List<Object?> get props => [tokens];
+}
+
+/// Event that occurs during a legacy atomic swap.
+class SwapEvent extends Equatable {
+  const SwapEvent({
+    required this.type,
+    required this.data,
+  });
+
+  factory SwapEvent.fromJson(JsonMap json) => SwapEvent(
+        type: json.value<String>('type'),
+        data: json.valueOrNull<JsonMap>('data'),
+      );
+
+  final String type;
+  final JsonMap? data;
+
+  JsonMap toJson() => {
+        'type': type,
+        if (data != null) 'data': data,
+      };
+
+  @override
+  List<Object?> get props => [type, data];
+}
+
+/// Detailed information about a swap and its events.
+class SwapStatus extends Equatable {
+  const SwapStatus({
+    required this.uuid,
+    required this.makerCoin,
+    required this.takerCoin,
+    required this.events,
+    this.success,
+  });
+
+  factory SwapStatus.fromJson(JsonMap json) => SwapStatus(
+        uuid: json.value<String>('uuid'),
+        makerCoin: json.value<String>('maker_coin'),
+        takerCoin: json.value<String>('taker_coin'),
+        events: (json.value<List>('events') as List)
+            .map((e) => SwapEvent.fromJson(e as JsonMap))
+            .toList(),
+        success: json.valueOrNull<bool>('success'),
+      );
+
+  final String uuid;
+  final String makerCoin;
+  final String takerCoin;
+  final List<SwapEvent> events;
+  final bool? success;
+
+  bool get isFinished => success != null;
+
+  JsonMap toJson() => {
+        'uuid': uuid,
+        'maker_coin': makerCoin,
+        'taker_coin': takerCoin,
+        'events': events.map((e) => e.toJson()).toList(),
+        if (success != null) 'success': success,
+      };
+
+  @override
+  List<Object?> get props => [uuid, makerCoin, takerCoin, events, success];
+}
+
+/// Result returned from initiating a buy or sell swap.
+class BuySellResult extends Equatable {
+  const BuySellResult({required this.uuid});
+
+  factory BuySellResult.fromJson(JsonMap json) =>
+      BuySellResult(uuid: json.value<String>('uuid'));
+
+  final String uuid;
+
+  JsonMap toJson() => {'uuid': uuid};
+
+  @override
+  List<Object?> get props => [uuid];
+}


### PR DESCRIPTION
## Summary
- implement swap models for legacy buy/sell and status data
- add RPC requests for buy/sell and swap status queries
- register `SwapManager` and expose it via the SDK
- create simple swap page in example app
- add swap action to asset page

## Testing
- `flutter pub get --enforce-lockfile --offline`
- `dart format` *(ran on changed files)*
- `flutter analyze` *(fails: 1460 issues found)*