### PR TITLE
fix(fee-info): update tendermint, erc20, and qrc20 `fee_details` response format

### DIFF
--- a/packages/komodo_defi_types/lib/komodo_defi_type_utils.dart
+++ b/packages/komodo_defi_types/lib/komodo_defi_type_utils.dart
@@ -3,6 +3,7 @@
 /// Utilities for types used throughout the Komodo DeFi Framework ecosystem.
 library komodo_defi_type_utils;
 
+export 'src/utils/backoff_strategy.dart';
 export 'src/utils/iterable_type_utils.dart';
 export 'src/utils/json_type_utils.dart';
 export 'src/utils/live_data.dart';

--- a/packages/komodo_defi_types/lib/src/transactions/fee_info.freezed.dart
+++ b/packages/komodo_defi_types/lib/src/transactions/fee_info.freezed.dart
@@ -232,7 +232,10 @@ class _$FeeInfoUtxoPerKbyteCopyWithImpl<$Res>
 
 class FeeInfoEthGas extends FeeInfo {
   const FeeInfoEthGas(
-      {required this.coin, required this.gasPrice, required this.gas})
+      {required this.coin,
+      required this.gasPrice,
+      required this.gas,
+      this.totalGasFee})
       : super._();
 
   @override
@@ -243,6 +246,10 @@ class FeeInfoEthGas extends FeeInfo {
 
   /// Gas limit (number of gas units)
   final int gas;
+
+  /// Optional total fee override. If provided, this value will be used directly
+  /// instead of calculating from gasPrice * gas.
+  final Decimal? totalGasFee;
 
   /// Create a copy of FeeInfo
   /// with the given fields replaced by the non-null parameter values.
@@ -260,15 +267,18 @@ class FeeInfoEthGas extends FeeInfo {
             (identical(other.coin, coin) || other.coin == coin) &&
             (identical(other.gasPrice, gasPrice) ||
                 other.gasPrice == gasPrice) &&
-            (identical(other.gas, gas) || other.gas == gas));
+            (identical(other.gas, gas) || other.gas == gas) &&
+            (identical(other.totalGasFee, totalGasFee) ||
+                other.totalGasFee == totalGasFee));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, coin, gasPrice, gas);
+  int get hashCode =>
+      Object.hash(runtimeType, coin, gasPrice, gas, totalGasFee);
 
   @override
   String toString() {
-    return 'FeeInfo.ethGas(coin: $coin, gasPrice: $gasPrice, gas: $gas)';
+    return 'FeeInfo.ethGas(coin: $coin, gasPrice: $gasPrice, gas: $gas, totalGasFee: $totalGasFee)';
   }
 }
 
@@ -280,7 +290,7 @@ abstract mixin class $FeeInfoEthGasCopyWith<$Res>
       _$FeeInfoEthGasCopyWithImpl;
   @override
   @useResult
-  $Res call({String coin, Decimal gasPrice, int gas});
+  $Res call({String coin, Decimal gasPrice, int gas, Decimal? totalGasFee});
 }
 
 /// @nodoc
@@ -299,6 +309,7 @@ class _$FeeInfoEthGasCopyWithImpl<$Res>
     Object? coin = null,
     Object? gasPrice = null,
     Object? gas = null,
+    Object? totalGasFee = freezed,
   }) {
     return _then(FeeInfoEthGas(
       coin: null == coin
@@ -313,6 +324,10 @@ class _$FeeInfoEthGasCopyWithImpl<$Res>
           ? _self.gas
           : gas // ignore: cast_nullable_to_non_nullable
               as int,
+      totalGasFee: freezed == totalGasFee
+          ? _self.totalGasFee
+          : totalGasFee // ignore: cast_nullable_to_non_nullable
+              as Decimal?,
     ));
   }
 }
@@ -321,7 +336,10 @@ class _$FeeInfoEthGasCopyWithImpl<$Res>
 
 class FeeInfoQrc20Gas extends FeeInfo {
   const FeeInfoQrc20Gas(
-      {required this.coin, required this.gasPrice, required this.gasLimit})
+      {required this.coin,
+      required this.gasPrice,
+      required this.gasLimit,
+      this.totalGasFee})
       : super._();
 
   @override
@@ -332,6 +350,10 @@ class FeeInfoQrc20Gas extends FeeInfo {
 
   /// Gas limit
   final int gasLimit;
+
+  /// Optional total gas fee in coin units. If not provided, it will be calculated
+  /// as `gasPrice * gasLimit`.
+  final Decimal? totalGasFee;
 
   /// Create a copy of FeeInfo
   /// with the given fields replaced by the non-null parameter values.
@@ -350,15 +372,18 @@ class FeeInfoQrc20Gas extends FeeInfo {
             (identical(other.gasPrice, gasPrice) ||
                 other.gasPrice == gasPrice) &&
             (identical(other.gasLimit, gasLimit) ||
-                other.gasLimit == gasLimit));
+                other.gasLimit == gasLimit) &&
+            (identical(other.totalGasFee, totalGasFee) ||
+                other.totalGasFee == totalGasFee));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, coin, gasPrice, gasLimit);
+  int get hashCode =>
+      Object.hash(runtimeType, coin, gasPrice, gasLimit, totalGasFee);
 
   @override
   String toString() {
-    return 'FeeInfo.qrc20Gas(coin: $coin, gasPrice: $gasPrice, gasLimit: $gasLimit)';
+    return 'FeeInfo.qrc20Gas(coin: $coin, gasPrice: $gasPrice, gasLimit: $gasLimit, totalGasFee: $totalGasFee)';
   }
 }
 
@@ -370,7 +395,8 @@ abstract mixin class $FeeInfoQrc20GasCopyWith<$Res>
       _$FeeInfoQrc20GasCopyWithImpl;
   @override
   @useResult
-  $Res call({String coin, Decimal gasPrice, int gasLimit});
+  $Res call(
+      {String coin, Decimal gasPrice, int gasLimit, Decimal? totalGasFee});
 }
 
 /// @nodoc
@@ -389,6 +415,7 @@ class _$FeeInfoQrc20GasCopyWithImpl<$Res>
     Object? coin = null,
     Object? gasPrice = null,
     Object? gasLimit = null,
+    Object? totalGasFee = freezed,
   }) {
     return _then(FeeInfoQrc20Gas(
       coin: null == coin
@@ -403,6 +430,10 @@ class _$FeeInfoQrc20GasCopyWithImpl<$Res>
           ? _self.gasLimit
           : gasLimit // ignore: cast_nullable_to_non_nullable
               as int,
+      totalGasFee: freezed == totalGasFee
+          ? _self.totalGasFee
+          : totalGasFee // ignore: cast_nullable_to_non_nullable
+              as Decimal?,
     ));
   }
 }

--- a/packages/komodo_defi_types/lib/src/transactions/fee_info.freezed.dart
+++ b/packages/komodo_defi_types/lib/src/transactions/fee_info.freezed.dart
@@ -497,4 +497,93 @@ class _$FeeInfoCosmosGasCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
+
+class FeeInfoTendermint extends FeeInfo {
+  const FeeInfoTendermint(
+      {required this.coin, required this.amount, required this.gasLimit})
+      : super._();
+
+  @override
+  final String coin;
+
+  /// The fee amount in coin units
+  final Decimal amount;
+
+  /// Gas limit
+  final int gasLimit;
+
+  /// Create a copy of FeeInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $FeeInfoTendermintCopyWith<FeeInfoTendermint> get copyWith =>
+      _$FeeInfoTendermintCopyWithImpl<FeeInfoTendermint>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is FeeInfoTendermint &&
+            (identical(other.coin, coin) || other.coin == coin) &&
+            (identical(other.amount, amount) || other.amount == amount) &&
+            (identical(other.gasLimit, gasLimit) ||
+                other.gasLimit == gasLimit));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, coin, amount, gasLimit);
+
+  @override
+  String toString() {
+    return 'FeeInfo.tendermint(coin: $coin, amount: $amount, gasLimit: $gasLimit)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $FeeInfoTendermintCopyWith<$Res>
+    implements $FeeInfoCopyWith<$Res> {
+  factory $FeeInfoTendermintCopyWith(
+          FeeInfoTendermint value, $Res Function(FeeInfoTendermint) _then) =
+      _$FeeInfoTendermintCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String coin, Decimal amount, int gasLimit});
+}
+
+/// @nodoc
+class _$FeeInfoTendermintCopyWithImpl<$Res>
+    implements $FeeInfoTendermintCopyWith<$Res> {
+  _$FeeInfoTendermintCopyWithImpl(this._self, this._then);
+
+  final FeeInfoTendermint _self;
+  final $Res Function(FeeInfoTendermint) _then;
+
+  /// Create a copy of FeeInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? coin = null,
+    Object? amount = null,
+    Object? gasLimit = null,
+  }) {
+    return _then(FeeInfoTendermint(
+      coin: null == coin
+          ? _self.coin
+          : coin // ignore: cast_nullable_to_non_nullable
+              as String,
+      amount: null == amount
+          ? _self.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as Decimal,
+      gasLimit: null == gasLimit
+          ? _self.gasLimit
+          : gasLimit // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
 // dart format on

--- a/packages/komodo_ui/lib/src/core/displays/fee_info_display.dart
+++ b/packages/komodo_ui/lib/src/core/displays/fee_info_display.dart
@@ -99,6 +99,19 @@ class FeeInfoDisplay extends StatelessWidget {
                 style: Theme.of(context).textTheme.labelLarge,
               ),
             ],
+
+            final FeeInfoTendermint fee => [
+              Text('Gas Limit:', style: Theme.of(context).textTheme.bodyMedium),
+              Text(
+                '${fee.gasLimit}',
+                style: Theme.of(context).textTheme.labelLarge,
+              ),
+              Text('Amount:', style: Theme.of(context).textTheme.bodyMedium),
+              Text(
+                fee.formatTotal(precision: 8),
+                style: Theme.of(context).textTheme.labelLarge,
+              ),
+            ],
           },
 
           const SizedBox(height: 4),


### PR DESCRIPTION
Updated `FeeInfo` fields to match the response structure in the [docs](https://komodoplatform.com/en/docs/komodo-defi-framework/api/v20/wallet/tx/withdraw/), which includes new `total_` gas amount fields in the response.

Fixed `toJson` format for QRC20 and Tendermint coins, which expect f64 (double/decimal) values instead of string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a new "Tendermint" fee type, allowing display and handling of Tendermint transaction fees.
  - Fee breakdown UI now displays Tendermint fee details, including gas limit and amount.

- **Enhancements**
  - Improved Ethereum and QRC20 fee types with optional explicit total gas fee values for more accurate fee calculations and display.

- **Chores**
  - Updated package exports to include additional utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->