### PR TITLE
feat: add ibc source channel support

### DIFF
--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/withdrawal/withdraw_request.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/withdrawal/withdraw_request.dart
@@ -39,7 +39,7 @@ class WithdrawRequest
   final WithdrawalSource? from;
   final String? memo;
   final bool max;
-  final String? ibcSourceChannel;
+  final int? ibcSourceChannel;
 
   @override
   Map<String, dynamic> toJson() => {
@@ -52,9 +52,6 @@ class WithdrawRequest
       if (fee != null) 'fee': fee!.toJson(),
       if (from != null) 'from': from!.toRpcParams(),
       if (memo != null) 'memo': memo,
-      //TODO! Migrate breaking changes when the ibc_source_channel is
-      // changed to a numeric type in KDF.
-      // https://github.com/KomodoPlatform/komodo-defi-framework/pull/2298#discussion_r2034825504
       if (ibcSourceChannel != null) 'ibc_source_channel': ibcSourceChannel,
     },
   };

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/withdrawal/withdrawal_rpc_namespace.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/withdrawal/withdrawal_rpc_namespace.dart
@@ -18,6 +18,7 @@ class WithdrawMethodsNamespace extends BaseRpcMethodNamespace {
         from: params.from,
         memo: params.memo,
         max: params.isMax ?? false,
+        ibcSourceChannel: params.ibcSourceChannel,
       ),
     );
   }

--- a/packages/komodo_defi_sdk/example/lib/screens/withdrawal_page.dart
+++ b/packages/komodo_defi_sdk/example/lib/screens/withdrawal_page.dart
@@ -113,6 +113,9 @@ class _WithdrawalScreenState extends State<WithdrawalScreen> {
         memo: _memoController.text.isEmpty ? null : _memoController.text,
         isMax: _isMaxAmount,
         ibcTransfer: _isIbcTransfer ? true : null,
+        ibcSourceChannel: _isIbcTransfer
+            ? int.tryParse(_ibcChannelController.text)
+            : null,
       );
 
       final preview = await _sdk.withdrawals.previewWithdrawal(params);
@@ -326,6 +329,7 @@ class _WithdrawalScreenState extends State<WithdrawalScreen> {
                       labelText: 'IBC Channel',
                       hintText: 'Enter IBC channel ID',
                     ),
+                    keyboardType: TextInputType.number,
                     validator:
                         (value) =>
                             value?.isEmpty == true

--- a/packages/komodo_defi_types/lib/src/withdrawal/withdrawal_types.dart
+++ b/packages/komodo_defi_types/lib/src/withdrawal/withdrawal_types.dart
@@ -153,6 +153,7 @@ class WithdrawParameters extends Equatable {
     this.from,
     this.memo,
     this.ibcTransfer,
+    this.ibcSourceChannel,
     this.isMax,
   }) : assert(
           amount != null || (isMax ?? false),
@@ -166,6 +167,7 @@ class WithdrawParameters extends Equatable {
   final WithdrawalSource? from;
   final String? memo;
   final bool? ibcTransfer;
+  final int? ibcSourceChannel;
   final bool? isMax;
 
   JsonMap toJson() => {
@@ -177,6 +179,7 @@ class WithdrawParameters extends Equatable {
         if (from != null) 'from': from!.toRpcParams(),
         if (memo != null) 'memo': memo,
         if (ibcTransfer != null) 'ibc_transfer': ibcTransfer,
+        if (ibcSourceChannel != null) 'ibc_source_channel': ibcSourceChannel,
       };
 
   @override
@@ -188,6 +191,7 @@ class WithdrawParameters extends Equatable {
         from,
         memo,
         ibcTransfer,
+        ibcSourceChannel,
         isMax,
       ];
 }


### PR DESCRIPTION
## Summary
- support `ibc_source_channel` when creating withdraw requests
- expose `ibcSourceChannel` on `WithdrawParameters`
- pass the channel from the withdrawal screen example

## Testing
- `dart format -o none --set-exit-if-changed .`
- `flutter analyze --no-pub` *(fails: 1359 issues found)*