### PR TITLE
Feat/ibc channel param

### DIFF
--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -63,7 +63,7 @@
     "coins": {
         "fetch_at_build_enabled": true,
         "update_commit_on_build": true,
-        "bundled_coins_repo_commit": "cbbfe2dc83a8c5f037bcbef21737acd86b85b543",
+        "bundled_coins_repo_commit": "c4713dd3b5a68351136b850de6e6db99e57a2b8d",
         "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",
         "coins_repo_content_url": "https://komodoplatform.github.io/coins",
         "coins_repo_branch": "master",

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/withdrawal/withdraw_request.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/withdrawal/withdraw_request.dart
@@ -39,6 +39,7 @@ class WithdrawRequest
   final WithdrawalSource? from;
   final String? memo;
   final bool max;
+  // TODO: update to `int?` when the KDF changes in v2.5.0-beta
   final String? ibcSourceChannel;
 
   @override

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/withdrawal/withdrawal_rpc_namespace.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/withdrawal/withdrawal_rpc_namespace.dart
@@ -18,6 +18,7 @@ class WithdrawMethodsNamespace extends BaseRpcMethodNamespace {
         from: params.from,
         memo: params.memo,
         max: params.isMax ?? false,
+        ibcSourceChannel: params.ibcSourceChannel,
       ),
     );
   }

--- a/packages/komodo_defi_sdk/example/lib/screens/withdrawal_page.dart
+++ b/packages/komodo_defi_sdk/example/lib/screens/withdrawal_page.dart
@@ -113,6 +113,7 @@ class _WithdrawalScreenState extends State<WithdrawalScreen> {
         memo: _memoController.text.isEmpty ? null : _memoController.text,
         isMax: _isMaxAmount,
         ibcTransfer: _isIbcTransfer ? true : null,
+        ibcSourceChannel: _isIbcTransfer ? _ibcChannelController.text : null,
       );
 
       final preview = await _sdk.withdrawals.previewWithdrawal(params);
@@ -324,13 +325,17 @@ class _WithdrawalScreenState extends State<WithdrawalScreen> {
                     controller: _ibcChannelController,
                     decoration: const InputDecoration(
                       labelText: 'IBC Channel',
-                      hintText: 'Enter IBC channel ID',
+                      hintText: 'Enter IBC channel ID (e.g. channel-141)',
                     ),
-                    validator:
-                        (value) =>
-                            value?.isEmpty == true
-                                ? 'Please enter IBC channel'
-                                : null,
+                    validator: (value) {
+                      if (value?.isEmpty == true) {
+                        return 'Please enter IBC channel';
+                      }
+                      if (!RegExp(r'^channel-\d+$').hasMatch(value!)) {
+                        return 'Channel must be in format "channel-" followed by a number';
+                      }
+                      return null;
+                    },
                   ),
                 ],
               ],

--- a/packages/komodo_defi_types/lib/src/transactions/fee_info.dart
+++ b/packages/komodo_defi_types/lib/src/transactions/fee_info.dart
@@ -235,10 +235,13 @@ sealed class FeeInfo with _$FeeInfo {
             'gas_price': gasPrice.toDouble(),
             'gas_limit': gasLimit,
           },
+        // TODO: update to Tendermint for KDF v2.5.0-beta
         FeeInfoTendermint(:final coin, :final amount, :final gasLimit) => {
-            'type': 'Tendermint',
+            'type': 'CosmosGas',
             'coin': coin,
-            'amount': amount.toString(),
+            'gas_price': gasLimit > 0 
+                ? (amount / Decimal.fromInt(gasLimit)).toDouble()
+                : 0.0,
             'gas_limit': gasLimit,
           },
       };

--- a/packages/komodo_defi_types/lib/src/withdrawal/withdrawal_types.dart
+++ b/packages/komodo_defi_types/lib/src/withdrawal/withdrawal_types.dart
@@ -153,6 +153,7 @@ class WithdrawParameters extends Equatable {
     this.from,
     this.memo,
     this.ibcTransfer,
+    this.ibcSourceChannel,
     this.isMax,
   }) : assert(
           amount != null || (isMax ?? false),
@@ -166,6 +167,7 @@ class WithdrawParameters extends Equatable {
   final WithdrawalSource? from;
   final String? memo;
   final bool? ibcTransfer;
+  final String? ibcSourceChannel;
   final bool? isMax;
 
   JsonMap toJson() => {
@@ -177,6 +179,7 @@ class WithdrawParameters extends Equatable {
         if (from != null) 'from': from!.toRpcParams(),
         if (memo != null) 'memo': memo,
         if (ibcTransfer != null) 'ibc_transfer': ibcTransfer,
+        if (ibcSourceChannel != null) 'ibc_source_channel': ibcSourceChannel,
       };
 
   @override
@@ -188,6 +191,7 @@ class WithdrawParameters extends Equatable {
         from,
         memo,
         ibcTransfer,
+        ibcSourceChannel,
         isMax,
       ];
 }


### PR DESCRIPTION
Modified version of #62 to continue using `String` rather than `int`. 

KDF `main` branch does not yet have the breaking type change for `ibcSourceChannel`, so this PR makes similar changes to the original:

- Add `ibc_source_channel` parameter to the WithdrawRequest model and RPC 
- Pass source channel from withdraw page to RPC
- Add validation to the withdraw page to ensure that the channel ID is in the expected format