### PR TITLE
Fix CDN usage in GitHubFileDownloader

### DIFF
--- a/packages/komodo_wallet_build_transformer/lib/src/steps/github/github_file_downloader.dart
+++ b/packages/komodo_wallet_build_transformer/lib/src/steps/github/github_file_downloader.dart
@@ -130,15 +130,18 @@ class GitHubFileDownloader {
     }
   }
 
-  Future<String> _fetchFileContent(String fileUrl, String repoCommit) async {
-    final isRawContentUrl = fileUrl.startsWith(
+  Future<String> _fetchFileContent(
+    String relativeFilePath,
+    String repoCommit,
+  ) async {
+    final isRawContentUrl = relativeFilePath.startsWith(
       'https://raw.githubusercontent.com',
     );
 
     final fileContentUrl = Uri.parse(
       isRawContentUrl
-          ? '$repoContentUrl/$repoCommit/$fileUrl'
-          : '$repoContentUrl/$fileUrl',
+          ? '$repoContentUrl/$repoCommit/$relativeFilePath'
+          : '$repoContentUrl/$relativeFilePath',
     );
 
     _log.fine('Fetching file content from: $fileContentUrl');
@@ -152,6 +155,15 @@ class GitHubFileDownloader {
     }
 
     return response.body;
+  }
+
+  String _buildFileDownloadUrl(String filePath, String repoCommit) {
+    final isRawContentUrl = repoContentUrl.contains(
+      'raw.githubusercontent.com',
+    );
+    return isRawContentUrl
+        ? '$repoContentUrl/$repoCommit/$filePath'
+        : '$repoContentUrl/$filePath';
   }
 
   /// Downloads the mapped folders from a GitHub repository at a specific commit
@@ -184,7 +196,7 @@ class GitHubFileDownloader {
           _log.fine(
             'Downloading ${entry.value.length} files from ${entry.key}',
           );
-          await _downloadFolderContents(entry.key, entry.value);
+          await _downloadFolderContents(entry.key, entry.value, repoCommit);
         }).toList();
 
     await Future.wait(downloadFutures);
@@ -210,7 +222,7 @@ class GitHubFileDownloader {
     );
     for (final entry in folderContents.entries) {
       _log.fine('Downloading ${entry.value.length} files from ${entry.key}');
-      await _downloadFolderContentsSync(entry.key, entry.value);
+      await _downloadFolderContentsSync(entry.key, entry.value, repoCommit);
     }
 
     sendPort?.send(
@@ -226,9 +238,19 @@ class GitHubFileDownloader {
   Future<void> _downloadFolderContentsSync(
     String key,
     List<GitHubFile> value,
+    String repoCommit,
   ) async {
+    final filesWithCdn =
+        value
+            .map(
+              (file) => file.copyWith(
+                downloadUrl: _buildFileDownloadUrl(file.path, repoCommit),
+              ),
+            )
+            .toList();
+
     await for (final GitHubFileDownloadEvent event in downloadFiles(
-      value,
+      filesWithCdn,
       key,
     )) {
       switch (event.event) {
@@ -253,12 +275,16 @@ class GitHubFileDownloader {
   Future<void> _downloadFolderContents(
     String key,
     List<GitHubFile> value,
+    String repoCommit,
   ) async {
     final List<Future<void>> downloadFutures =
         value.map((file) async {
+          final fileWithCdn = file.copyWith(
+            downloadUrl: _buildFileDownloadUrl(file.path, repoCommit),
+          );
           await for (final GitHubFileDownloadEvent event in downloadFiles([
-            file,
-          ], key)) {
+            fileWithCdn,
+          ], key,)) {
             switch (event.event) {
               case GitHubDownloadEvent.downloaded:
                 _downloadedFiles++;

--- a/packages/komodo_wallet_build_transformer/lib/src/steps/github/github_file_downloader.dart
+++ b/packages/komodo_wallet_build_transformer/lib/src/steps/github/github_file_downloader.dart
@@ -284,7 +284,7 @@ class GitHubFileDownloader {
           );
           await for (final GitHubFileDownloadEvent event in downloadFiles([
             fileWithCdn,
-          ], key,)) {
+          ], key)) {
             switch (event.event) {
               case GitHubDownloadEvent.downloaded:
                 _downloadedFiles++;
@@ -384,6 +384,7 @@ class GitHubFileDownloader {
     }
 
     try {
+      _log.finer('Downloading icon for $coinName: ${item.downloadUrl}');
       final fileResponse = await http.read(Uri.parse(item.downloadUrl));
       if (fileResponse.isEmpty) {
         throw Exception('Failed to download file: ${item.downloadUrl}');


### PR DESCRIPTION
## Summary
- fix CDN url usage when downloading folders in GitHubFileDownloader
- rename `_fetchFileContent` argument

## Testing
- `flutter pub get --enforce-lockfile --offline`
- `dart format packages/komodo_wallet_build_transformer/lib/src/steps/github/github_file_downloader.dart`
- `dart fix --apply`
- `flutter analyze` *(fails: many existing issues)*
- `flutter build web` *(fails to fetch packages offline)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the reliability of file downloads from GitHub repositories by standardizing how download URLs are constructed, ensuring files are fetched accurately based on the repository commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->