### PR TITLE
Add reusable dApp browser widget

### DIFF
--- a/packages/komodo_defi_sdk/CHANGELOG.md
+++ b/packages/komodo_defi_sdk/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.1+0
+- feat: add EIP-1193 and Komodo provider classes
+
 # 0.1.0+1
 
 - feat: initial commit 🎉

--- a/packages/komodo_defi_sdk/example/lib/main.dart
+++ b/packages/komodo_defi_sdk/example/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:kdf_sdk_example/screens/asset_page.dart';
 import 'package:kdf_sdk_example/widgets/instance_manager/instance_view.dart';
 import 'package:kdf_sdk_example/widgets/instance_manager/kdf_instance_drawer.dart';
 import 'package:kdf_sdk_example/widgets/instance_manager/kdf_instance_state.dart';
+import 'package:kdf_sdk_example/screens/dapp_browser_page.dart';
 import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 
@@ -183,6 +184,10 @@ class _KomodoAppState extends State<KomodoApp> {
             ),
             const SizedBox(width: 16),
           ],
+          IconButton(
+            icon: const Icon(Icons.web),
+            onPressed: () => _openBrowser(instances[_selectedInstanceIndex]),
+          ),
         ],
       ),
       body:
@@ -244,6 +249,14 @@ class _KomodoAppState extends State<KomodoApp> {
   void _onNavigateToAsset(KdfInstanceState instance, Asset asset) {
     _navigatorKey.currentState?.push(
       MaterialPageRoute<void>(builder: (context) => AssetPage(asset)),
+    );
+  }
+
+  void _openBrowser(KdfInstanceState instance) {
+    _navigatorKey.currentState?.push(
+      MaterialPageRoute<void>(
+        builder: (_) => DappBrowserPage(sdk: instance.sdk),
+      ),
     );
   }
 

--- a/packages/komodo_defi_sdk/example/lib/screens/dapp_browser_page.dart
+++ b/packages/komodo_defi_sdk/example/lib/screens/dapp_browser_page.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
+import 'package:komodo_ui/komodo_ui.dart';
+
+/// Simple page showcasing the [DappBrowser] widget.
+class DappBrowserPage extends StatelessWidget {
+  const DappBrowserPage({required this.sdk, super.key});
+
+  final KomodoDefiSdk sdk;
+
+  @override
+  Widget build(BuildContext context) {
+    final evmProvider = EvmProvider(sdk.client);
+    final komodoProvider = KomodoProvider(sdk.client);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('dApp Browser')),
+      body: DappBrowser(
+        initialUrl: 'https://uniswap.org',
+        evmProvider: evmProvider,
+        komodoProvider: komodoProvider,
+      ),
+    );
+  }
+}

--- a/packages/komodo_defi_sdk/lib/komodo_defi_sdk.dart
+++ b/packages/komodo_defi_sdk/lib/komodo_defi_sdk.dart
@@ -22,4 +22,7 @@ export 'src/assets/asset_extensions.dart'
 export 'src/assets/asset_pubkey_extensions.dart';
 export 'src/assets/legacy_asset_extensions.dart';
 export 'src/komodo_defi_sdk.dart' show KomodoDefiSdk;
+export 'src/providers/evm_provider.dart';
+export 'src/providers/komodo_provider.dart';
+export 'src/providers/multi_chain_switcher.dart';
 export 'src/widgets/asset_balance_text.dart';

--- a/packages/komodo_defi_sdk/lib/src/providers/evm_provider.dart
+++ b/packages/komodo_defi_sdk/lib/src/providers/evm_provider.dart
@@ -1,0 +1,33 @@
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+/// {@template evm_provider}
+/// Basic EIP-1193 provider implementation used for WebView injection.
+/// {@endtemplate}
+class EvmProvider {
+  /// {@macro evm_provider}
+  EvmProvider(this._client);
+
+  final ApiClient _client;
+
+  /// Current active EVM chain ID in hexadecimal string format.
+  String? currentChainId;
+
+  /// Sends an EIP-1193 request to the underlying client.
+  Future<dynamic> request({required String method, dynamic params}) async {
+    final rpcRequest = <String, dynamic>{
+      'method': method,
+      if (params != null) 'params': params,
+    };
+    final response = await _client.executeRpc(rpcRequest);
+    return response['result'];
+  }
+
+  /// Convenience helper for `wallet_switchEthereumChain`.
+  Future<void> switchChain(String chainId) async {
+    await request(
+      method: 'wallet_switchEthereumChain',
+      params: {'chainId': chainId},
+    );
+    currentChainId = chainId;
+  }
+}

--- a/packages/komodo_defi_sdk/lib/src/providers/komodo_provider.dart
+++ b/packages/komodo_defi_sdk/lib/src/providers/komodo_provider.dart
@@ -1,0 +1,21 @@
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+/// {@template komodo_provider}
+/// Provider wrapper exposing `komodo.request` for dApp consumption.
+/// {@endtemplate}
+class KomodoProvider {
+  /// {@macro komodo_provider}
+  KomodoProvider(this._client);
+
+  final ApiClient _client;
+
+  /// Executes a Komodo RPC method.
+  Future<dynamic> request({required String method, dynamic params}) async {
+    final rpcRequest = <String, dynamic>{
+      'method': method,
+      if (params != null) 'params': params,
+    };
+    final response = await _client.executeRpc(rpcRequest);
+    return response['result'];
+  }
+}

--- a/packages/komodo_defi_sdk/lib/src/providers/multi_chain_switcher.dart
+++ b/packages/komodo_defi_sdk/lib/src/providers/multi_chain_switcher.dart
@@ -1,0 +1,20 @@
+import 'evm_provider.dart';
+
+/// {@template multi_chain_switcher}
+/// Handles chain switching logic for injected providers.
+/// {@endtemplate}
+class MultiChainSwitcher {
+  /// {@macro multi_chain_switcher}
+  MultiChainSwitcher({required this.evmProvider});
+
+  /// The injected EVM provider.
+  final EvmProvider evmProvider;
+
+  /// Switches to the given EVM chain ID.
+  Future<void> switchEthereumChain(String chainId) async {
+    await evmProvider.switchChain(chainId);
+  }
+
+  /// Returns the current EVM chain ID or `null` if none is set.
+  String? get currentEthereumChainId => evmProvider.currentChainId;
+}

--- a/packages/komodo_defi_sdk/pubspec.yaml
+++ b/packages/komodo_defi_sdk/pubspec.yaml
@@ -3,7 +3,7 @@ description: A high-level opinionated library that provides a simple way to
   build cross-platform Komodo Defi Framework applications (primarily focused on
   wallets). This package seves as the entry point for the packages in this
   repository.
-version: 0.2.0+0
+version: 0.2.1+0
 
 # Temporarily set since published packages can't have path dependencies.
 # When this package is stable, the child packages will be published to pub.dev

--- a/packages/komodo_ui/lib/src/defi/browser/dapp_browser.dart
+++ b/packages/komodo_ui/lib/src/defi/browser/dapp_browser.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
+
+/// A lightweight in-app browser widget that injects [EvmProvider]
+/// and [KomodoProvider] into the WebView.
+class DappBrowser extends StatefulWidget {
+  const DappBrowser({
+    required this.initialUrl,
+    required this.evmProvider,
+    required this.komodoProvider,
+    super.key,
+  });
+
+  /// The initial URL to load.
+  final String initialUrl;
+
+  /// Provider used to handle `window.ethereum` requests.
+  final EvmProvider evmProvider;
+
+  /// Provider used to handle `window.komodo` requests.
+  final KomodoProvider komodoProvider;
+
+  @override
+  State<DappBrowser> createState() => _DappBrowserState();
+}
+
+class _DappBrowserState extends State<DappBrowser> {
+  late final WebViewController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller =
+        WebViewController()
+          ..setJavaScriptMode(JavaScriptMode.unrestricted)
+          ..setNavigationDelegate(NavigationDelegate())
+          ..loadRequest(Uri.parse(widget.initialUrl));
+    _setupHandlers();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WebViewWidget(controller: _controller);
+  }
+
+  Future<void> _setupHandlers() async {
+    await _injectProviders();
+    _controller.addJavaScriptChannel(
+      'evmProvider',
+      onMessageReceived: (message) async {
+        final data = message.message;
+        final map = Map<String, dynamic>.from(
+          jsonDecode(data) as Map<String, dynamic>,
+        );
+        final result = await widget.evmProvider.request(
+          method: map['method'] as String,
+          params: map['params'],
+        );
+        _controller.runJavaScript(
+          'window._resolveEvmRequest(${jsonEncode(result)})',
+        );
+      },
+    );
+    _controller.addJavaScriptChannel(
+      'komodoProvider',
+      onMessageReceived: (message) async {
+        final data = message.message;
+        final map = Map<String, dynamic>.from(
+          jsonDecode(data) as Map<String, dynamic>,
+        );
+        final result = await widget.komodoProvider.request(
+          method: map['method'] as String,
+          params: map['params'],
+        );
+        _controller.runJavaScript(
+          'window._resolveKomodoRequest(${jsonEncode(result)})',
+        );
+      },
+    );
+  }
+
+  Future<void> _injectProviders() async {
+    const js = '''
+      window.ethereum = {
+        request: function(args) {
+          return new Promise((resolve) => {
+            window._resolveEvmRequest = resolve;
+            window.evmProvider.postMessage(JSON.stringify(args));
+          });
+        }
+      };
+      window.komodo = {
+        request: function(args) {
+          return new Promise((resolve) => {
+            window._resolveKomodoRequest = resolve;
+            window.komodoProvider.postMessage(JSON.stringify(args));
+          });
+        }
+      };
+    ''';
+    await _controller.runJavaScript(js);
+  }
+}

--- a/packages/komodo_ui/lib/src/defi/index.dart
+++ b/packages/komodo_ui/lib/src/defi/index.dart
@@ -18,3 +18,4 @@ export 'withdraw/recipient_address_field.dart';
 export 'withdraw/source_address_field.dart';
 export 'withdraw/withdraw_amount_field.dart';
 export 'withdraw/withdraw_error_display.dart';
+export 'browser/dapp_browser.dart';

--- a/packages/komodo_ui/pubspec.yaml
+++ b/packages/komodo_ui/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   komodo_defi_types:
     path: ../komodo_defi_types
   mobile_scanner: ^6.0.3
+  webview_flutter: ^4.9.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `DappBrowser` widget to `komodo_ui`
- expose browser widget via package index
- wire up new screen in SDK example
- add icon button to open dApp browser
- depend on `webview_flutter`

## Testing
- `dart format packages/komodo_ui/lib/src/defi/browser/dapp_browser.dart packages/komodo_ui/lib/src/defi/index.dart packages/komodo_defi_sdk/example/lib/screens/dapp_browser_page.dart packages/komodo_defi_sdk/example/lib/main.dart`
- `flutter analyze --no-pub` *(fails: 2315 issues)*
- `flutter pub get --offline` *(fails: network issue)*