### PR TITLE
Remove Paste Button

### DIFF
--- a/packages/komodo_ui/lib/src/defi/withdraw/recipient_address_field.dart
+++ b/packages/komodo_ui/lib/src/defi/withdraw/recipient_address_field.dart
@@ -169,18 +169,12 @@ class _RecipientAddressFieldState extends State<RecipientAddressField> {
   /// Whether the text field currently has focus.
   bool _hasFocus = false;
 
-  /// Whether to show the paste button.
-  /// True when the field is empty, false when it contains text.
-  bool _showPasteButton = true;
 
   @override
   void initState() {
     super.initState();
     _controller = TextEditingController(text: widget.address);
     _focusNode.addListener(_onFocusChange);
-
-    // Update paste button visibility based on initial text
-    _showPasteButton = widget.address.isEmpty;
   }
 
   void _onFocusChange() {
@@ -194,7 +188,6 @@ class _RecipientAddressFieldState extends State<RecipientAddressField> {
     super.didUpdateWidget(oldWidget);
     if (widget.address != _controller.text) {
       _controller.text = widget.address;
-      _showPasteButton = widget.address.isEmpty;
     }
   }
 
@@ -205,19 +198,6 @@ class _RecipientAddressFieldState extends State<RecipientAddressField> {
       ..removeListener(_onFocusChange)
       ..dispose();
     super.dispose();
-  }
-
-  Future<void> _pasteFromClipboard() async {
-    final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
-    if (!mounted) return;
-
-    if (clipboardData?.text != null && clipboardData!.text!.isNotEmpty) {
-      _controller.text = clipboardData.text!;
-      widget.onChanged(clipboardData.text!);
-      setState(() {
-        _showPasteButton = false;
-      });
-    }
   }
 
   @override
@@ -277,20 +257,12 @@ class _RecipientAddressFieldState extends State<RecipientAddressField> {
             suffixIcon: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                if (_showPasteButton)
-                  TextButton(
-                    onPressed: _pasteFromClipboard,
-                    child: const Text('Paste'),
-                  )
-                else if (_controller.text.isNotEmpty)
+                if (_controller.text.isNotEmpty)
                   IconButton(
                     icon: const Icon(Icons.clear),
                     onPressed: () {
                       _controller.clear();
                       widget.onChanged('');
-                      setState(() {
-                        _showPasteButton = true;
-                      });
                     },
                     tooltip: 'Clear',
                   ),
@@ -311,10 +283,6 @@ class _RecipientAddressFieldState extends State<RecipientAddressField> {
             errorText: _getErrorText(),
           ),
           onChanged: (value) {
-            // Update UI state immediately
-            setState(() {
-              _showPasteButton = value.isEmpty;
-            });
 
             // Debounce the validation callback
             _validationDebouncer.run(() {
@@ -551,9 +519,6 @@ class _RecipientAddressFieldState extends State<RecipientAddressField> {
       _controller.text = scannedAddress;
       widget.onQrScanned?.call(scannedAddress);
       widget.onChanged(scannedAddress);
-      setState(() {
-        _showPasteButton = false;
-      });
     }
   }
 }


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/komodo-defi-sdk-flutter/issues/72 (issue migrated from wallet repo)

This PR removes the paste button in recipient address field UI and rather relying on the system's native paste functionality. This change makes the UI cleaner, safer and less likely to cause concern from security popups.

## Changes

### UI/UX Improvements
- Removed explicit paste button from the recipient address field
- Simplified state management by removing `_showPasteButton` tracking
- Removed unnecessary setState calls in various methods
- Users can still paste using standard system paste functionality (Ctrl+V/Cmd+V or right-click menu)

### Code Cleanup
- Removed `_pasteFromClipboard` method as it's no longer needed
- Removed state updates related to paste button visibility

## QA Test Plan

### Basic Functionality
1. Open any withdrawal screen with the recipient address field
2. Verify the field accepts text input normally
3. Verify address validation still works as expected
4. Verify the clear button (X) appears when text is entered and clears the field when clicked

### Paste Functionality
1. Copy a valid address to clipboard
2. Test pasting using:
   - Keyboard shortcut (Ctrl+V/Cmd+V)
   - Right-click context menu
   - Mobile long-press paste option
3. Verify the pasted address is validated correctly

### QR Code Scanner
1. Click the QR code scanner button
2. Scan a valid address QR code
3. Verify the address is populated in the field
4. Verify validation occurs after scanning

### Visual Verification
1. Check that the field looks clean without the paste button
2. Verify all states display correctly:
   - Empty state
   - Focus state
   - Valid address state (with checkmark)
   - Invalid address state (with error message)
   - Loading state during validation

### Edge Cases
1. Test with very long addresses
2. Test with invalid addresses
3. Test rapid input/paste operations
4. Test with empty clipboard
5. Verify no UI glitches when switching between states


@CharlVS To simplify testing, a CI build in the wallet repo would be appreciated. 