### PR TITLE
fix KDF not found warnings in _tryRenameFile of FetchDefiApiStep

### DIFF
--- a/packages/komodo_wallet_build_transformer/lib/src/steps/fetch_defi_api_build_step.dart
+++ b/packages/komodo_wallet_build_transformer/lib/src/steps/fetch_defi_api_build_step.dart
@@ -444,12 +444,9 @@ class FetchDefiApiStep extends BuildStep {
     required String destinationFolder,
   }) {
     _log.fine('Looking for KDF at: $filePath');
+    final newExecutableName = path.basename(filePath).replaceAll('mm2', 'kdf');
+    final newExecutablePath = path.join(destinationFolder, newExecutableName);
     if (FileSystemEntity.isFileSync(filePath)) {
-      final newExecutableName = path
-          .basename(filePath)
-          .replaceAll('mm2', 'kdf');
-      final newExecutablePath = path.join(destinationFolder, newExecutableName);
-
       try {
         File(filePath).renameSync(newExecutablePath);
         _log.info('Renamed kdf from $filePath to $newExecutableName');
@@ -457,7 +454,10 @@ class FetchDefiApiStep extends BuildStep {
         _log.severe('Failed to rename kdf: $e');
       }
     } else {
-      _log.warning('KDF not found at: $filePath');
+      // If it's already renamed, there's no need to log a warning.
+      if (!FileSystemEntity.isFileSync(newExecutablePath)) {
+        _log.warning('KDF not found at: $filePath');
+      }
     }
   }
 


### PR DESCRIPTION
If the KDF binaries were already renamed from `mm2` to `kdf`—i.e., if the target folder already contained `kdf.exe` or `libkdf.a` after the last successful rename from `*mm2*`—the warning `KDF not found at` would still appear, which was a bit confusing. Now, if the folder already contains the renamed binary, the warning no longer appears.

```
WARNING: 2025-06-05 21:26:40.476696: KDF not found at: /home/decker/.pub-cache/git/komodo-defi-sdk-flutter-4ecbdaba11f572aa3c46603622ad42d7ee995b1a/packages/komodo_defi_framework/ios/libmm2.a
INFO: 2025-06-05 21:26:40.476780: macos platform is up to date.
WARNING: 2025-06-05 21:26:40.476944: KDF not found at: /home/decker/.pub-cache/git/komodo-defi-sdk-flutter-4ecbdaba11f572aa3c46603622ad42d7ee995b1a/packages/komodo_defi_framework/macos/bin/mm2
INFO: 2025-06-05 21:26:40.477185: Setting executable permissions for /home/decker/.pub-cache/git/komodo-defi-sdk-flutter-4ecbdaba11f572aa3c46603622ad42d7ee995b1a/packages/komodo_defi_framework/macos/bin...
INFO: 2025-06-05 21:26:40.482725: windows platform is up to date.
WARNING: 2025-06-05 21:26:40.482789: KDF not found at: /home/decker/.pub-cache/git/komodo-defi-sdk-flutter-4ecbdaba11f572aa3c46603622ad42d7ee995b1a/packages/komodo_defi_framework/windows/bin/mm2.exe
INFO: 2025-06-05 21:26:40.482815: Setting executable permissions for /home/decker/.pub-cache/git/komodo-defi-sdk-flutter-4ecbdaba11f572aa3c46603622ad42d7ee995b1a/packages/komodo_defi_framework/windows/bin...
INFO: 2025-06-05 21:26:40.482878: android-armv7 platform is up to date.
WARNING: 2025-06-05 21:26:40.482923: KDF not found at: /home/decker/.pub-cache/git/komodo-defi-sdk-flutter-4ecbdaba11f572aa3c46603622ad42d7ee995b1a/packages/komodo_defi_framework/android/app/src/main/cpp/libs/armeabi-v7a/libmm2.a
INFO: 2025-06-05 21:26:40.482952: android-aarch64 platform is up to date.
WARNING: 2025-06-05 21:26:40.482993: KDF not found at: /home/decker/.pub-cache/git/komodo-defi-sdk-flutter-4ecbdaba11f572aa3c46603622ad42d7ee995b1a/packages/komodo_defi_framework/android/app/src/main/cpp/libs/arm64-v8a/libmm2.a
INFO: 2025-06-05 21:26:40.483021: linux platform is up to date.
WARNING: 2025-06-05 21:26:40.483061: KDF not found at: /home/decker/.pub-cache/git/komodo-defi-sdk-flutter-4ecbdaba11f572aa3c46603622ad42d7ee995b1a/packages/komodo_defi_framework/linux/bin/mm2
INFO: 2025-06-05 21:26:40.483084: Setting executable permissions for /home/decker/.pub-cache/git/komodo-defi-sdk-flutter-4ecbdaba11f572aa3c46603622ad42d7ee995b1a/packages/komodo_defi_framework/linux/bin...
```