### PR TITLE
Add AssetLogo widget

### DIFF
--- a/packages/komodo_defi_sdk/example/lib/widgets/assets/asset_item.dart
+++ b/packages/komodo_defi_sdk/example/lib/widgets/assets/asset_item.dart
@@ -38,7 +38,7 @@ class AssetItemWidget extends StatelessWidget {
         ],
       ),
       tileColor: isCompatible ? null : Colors.grey[200],
-      leading: AssetIcon(asset.id, size: 32),
+      leading: AssetLogo(asset, size: 32),
       trailing: _AssetItemTrailing(asset: asset, isEnabled: isCompatible),
       // ignore: avoid_redundant_argument_values
       enabled: isCompatible,

--- a/packages/komodo_ui/lib/komodo_ui.dart
+++ b/packages/komodo_ui/lib/komodo_ui.dart
@@ -26,6 +26,7 @@ export 'src/core/inputs/fee_info_input.dart';
 export 'src/core/inputs/search_coin_select.dart';
 export 'src/core/inputs/searchable_select.dart';
 export 'src/defi/asset/asset_icon.dart';
+export 'src/defi/asset/asset_logo.dart';
 export 'src/defi/asset/crypto_asset_card.dart';
 export 'src/defi/asset/metric_selector.dart';
 export 'src/defi/asset/trend_percentage_text.dart';

--- a/packages/komodo_ui/lib/src/defi/asset/asset_logo.dart
+++ b/packages/komodo_ui/lib/src/defi/asset/asset_logo.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+import 'package:komodo_ui/src/defi/asset/asset_icon.dart';
+
+/// A widget that displays an [AssetIcon] with its protocol icon overlaid.
+///
+/// Similar to the legacy [CoinLogo], but built on top of the new [Asset]
+/// and [AssetIcon] APIs.
+class AssetLogo extends StatelessWidget {
+  const AssetLogo(
+    this.asset, {
+    this.size = 20,
+    this.suspended = false,
+    super.key,
+  });
+
+  /// Asset to display the logo for.
+  final Asset asset;
+
+  /// Size of the main asset icon.
+  final double size;
+
+  /// Whether the asset is suspended. Suspended icons are displayed
+  /// with reduced opacity.
+  final bool suspended;
+
+  @override
+  Widget build(BuildContext context) {
+    final protocolTicker = asset.protocol.subClass.iconTicker;
+    final protocolIconSize = size / 2;
+
+    final protocolIcon =
+        protocolTicker.isEmpty
+            ? null
+            : AssetIcon.ofTicker(protocolTicker, size: protocolIconSize);
+
+    return SizedBox.square(
+      dimension: size,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          AssetIcon(asset.id, size: size, suspended: suspended),
+          if (protocolIcon != null)
+            Positioned(right: 0, bottom: 0, child: protocolIcon),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/komodo_ui/lib/src/defi/index.dart
+++ b/packages/komodo_ui/lib/src/defi/index.dart
@@ -10,6 +10,7 @@ library komodo_ui.defi;
 export 'package:decimal/decimal.dart' show Decimal;
 
 export 'asset/asset_icon.dart';
+export 'asset/asset_logo.dart';
 export 'asset/crypto_asset_card.dart';
 export 'asset/metric_selector.dart';
 export 'asset/trend_percentage_text.dart';


### PR DESCRIPTION
## Summary
- overlay protocol icons on AssetIcon via new AssetLogo
- export AssetLogo in komodo_ui index files
- show AssetLogo in example asset list

## Testing
- `flutter analyze packages/komodo_defi_sdk/example/lib/widgets/assets/asset_item.dart`
- `dart fix --apply packages/komodo_ui/lib/src/defi/asset/asset_logo.dart`
- `dart format packages/komodo_ui/lib/src/defi/asset/asset_logo.dart`
- `dart format packages/komodo_defi_sdk/example/lib/widgets/assets/asset_item.dart`
- `dart pub global activate melos` *(passes)*
- `flutter pub run index_generator` *(passes)*
- `melos bs` *(fails: froze during build_runner)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68469afce1108331a07b329957fa3488