### PR TITLE
removes BCH from _filteredCoins

### DIFF
--- a/packages/komodo_coins/lib/src/config_transform.dart
+++ b/packages/komodo_coins/lib/src/config_transform.dart
@@ -85,8 +85,7 @@ class CoinFilter {
   const CoinFilter();
 
   static const _filteredCoins = {
-    // TODO: Remove when BCH is changed to UTXO protocol in the config
-    'BCH': 'Bitcoin Cash',
+    // Add coins to be filtered out here
   };
 
   static const _filteredProtocolSubTypes = {


### PR DESCRIPTION
https://github.com/KomodoPlatform/coins/pull/1368#pullrequestreview-2908037482 has been merged, though logs revealed that app still filtered out BCH. I tracked it back to here.