### PR TITLE
fix(kdf): enable p2p in noAuth mode

### DIFF
--- a/packages/komodo_defi_framework/lib/src/config/kdf_startup_config.dart
+++ b/packages/komodo_defi_framework/lib/src/config/kdf_startup_config.dart
@@ -184,8 +184,8 @@ class KdfStartupConfig {
       hdAccountId: null,
       allowRegistrations: false,
       enableHd: false,
-      disableP2p: true,
-      seedNodes: [],
+      disableP2p: false,
+      seedNodes: ['seed01.kmdefi.net', 'seed02.kmdefi.net'],
       iAmSeed: false,
       isBootstrapNode: false,
     );

--- a/packages/komodo_defi_framework/lib/src/config/kdf_startup_config.dart
+++ b/packages/komodo_defi_framework/lib/src/config/kdf_startup_config.dart
@@ -6,6 +6,8 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:komodo_coins/komodo_coins.dart';
 import 'package:komodo_defi_framework/src/config/seed_node_validator.dart';
+import 'package:komodo_defi_framework/src/services/seed_node_service.dart'
+    show SeedNodeService;
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
@@ -185,7 +187,7 @@ class KdfStartupConfig {
       allowRegistrations: false,
       enableHd: false,
       disableP2p: false,
-      seedNodes: ['seed01.kmdefi.net', 'seed02.kmdefi.net'],
+      seedNodes: await SeedNodeService.fetchSeedNodes(),
       iAmSeed: false,
       isBootstrapNode: false,
     );


### PR DESCRIPTION
KW makes orderbook and swap-related requests in noAuth mode that requires p2p to be enabled. KDF crashes on startup and logins fail if orderbook requests are made when p2p is disabled.