### PR TITLE
feat(seed): update seed node format

### DIFF
--- a/packages/komodo_coin_updates/example/seed_nodes_example.dart
+++ b/packages/komodo_coin_updates/example/seed_nodes_example.dart
@@ -5,9 +5,10 @@ void main() async {
   try {
     // Fetch seed nodes from the remote source
     print('Fetching seed nodes from remote source...');
-    final seedNodes = await SeedNodeUpdater.fetchSeedNodes();
+    final (seedNodes: seedNodes, netId: netId) =
+        await SeedNodeUpdater.fetchSeedNodes();
 
-    print('Found ${seedNodes.length} seed nodes:');
+    print('Found ${seedNodes.length} seed nodes on netid $netId:');
     for (final node in seedNodes) {
       print('  - ${node.name}: ${node.host}');
       if (node.contact.isNotEmpty && node.contact.first.email.isNotEmpty) {

--- a/packages/komodo_coin_updates/test/seed_node_updater_test.dart
+++ b/packages/komodo_coin_updates/test/seed_node_updater_test.dart
@@ -9,11 +9,17 @@ void main() {
         SeedNode(
           name: 'seed-node-1',
           host: 'seed01.kmdefi.net',
+          type: 'domain',
+          wss: true,
+          netId: 8762,
           contact: [SeedNodeContact(email: '')],
         ),
         SeedNode(
           name: 'seed-node-2',
           host: 'seed02.kmdefi.net',
+          type: 'domain',
+          wss: true,
+          netId: 8762,
           contact: [SeedNodeContact(email: '')],
         ),
       ];

--- a/packages/komodo_defi_framework/lib/src/config/kdf_startup_config.dart
+++ b/packages/komodo_defi_framework/lib/src/config/kdf_startup_config.dart
@@ -168,6 +168,11 @@ class KdfStartupConfig {
   }) async {
     final (String? home, String? dbDir) = await _getAndSetupUserHome();
 
+    final (
+      seedNodes: seeds,
+      netId: netId,
+    ) = await SeedNodeService.fetchSeedNodes();
+
     return KdfStartupConfig._(
       walletName: null,
       walletPassword: null,
@@ -176,7 +181,7 @@ class KdfStartupConfig {
       userHome: home,
       dbDir: dbDir,
       allowWeakPassword: true,
-      netid: 8762,
+      netid: netId,
       gui: 'komodo-defi-flutter-auth',
       coins: await _fetchCoinsData(),
       https: false,
@@ -187,7 +192,7 @@ class KdfStartupConfig {
       allowRegistrations: false,
       enableHd: false,
       disableP2p: false,
-      seedNodes: await SeedNodeService.fetchSeedNodes(),
+      seedNodes: seeds,
       iAmSeed: false,
       isBootstrapNode: false,
     );

--- a/packages/komodo_defi_framework/lib/src/services/seed_node_service.dart
+++ b/packages/komodo_defi_framework/lib/src/services/seed_node_service.dart
@@ -1,30 +1,43 @@
 import 'package:komodo_coin_updates/komodo_coin_updates.dart';
+import 'package:flutter/foundation.dart';
 import 'package:komodo_defi_framework/src/config/kdf_logging_config.dart';
 import 'package:komodo_defi_framework/src/config/seed_node_validator.dart';
 
 /// Service class responsible for fetching and managing seed nodes.
-/// 
-/// This class follows the Single Responsibility Principle by focusing 
+///
+/// This class follows the Single Responsibility Principle by focusing
 /// solely on seed node acquisition and management.
 class SeedNodeService {
   /// Fetches seed nodes from the remote configuration with fallback to defaults.
   ///
-  /// This method attempts to fetch the latest seed nodes from the Komodo Platform 
-  /// repository and converts them to the string format expected by the KDF startup 
+  /// This method attempts to fetch the latest seed nodes from the Komodo Platform
+  /// repository and converts them to the string format expected by the KDF startup
   /// configuration.
   ///
   /// Returns a list of seed node host addresses. If fetching fails, returns
   /// the hardcoded default seed nodes as a fallback.
-  static Future<List<String>> fetchSeedNodes() async {
+  static Future<({List<String> seedNodes, int netId})> fetchSeedNodes({
+    bool filterForWeb = kIsWeb,
+  }) async {
     try {
-      final seedNodes = await SeedNodeUpdater.fetchSeedNodes();
-      return SeedNodeUpdater.seedNodesToStringList(seedNodes);
+      final (
+        seedNodes: nodes,
+        netId: netId,
+      ) = await SeedNodeUpdater.fetchSeedNodes(filterForWeb: filterForWeb);
+
+      return (
+        seedNodes: SeedNodeUpdater.seedNodesToStringList(nodes),
+        netId: netId,
+      );
     } catch (e) {
       if (KdfLoggingConfig.verboseLogging) {
         print('WARN Failed to fetch seed nodes from remote: $e');
         print('WARN Falling back to default seed nodes');
       }
-      return getDefaultSeedNodes();
+      return (
+        seedNodes: getDefaultSeedNodes(),
+        netId: 8762,
+      );
     }
   }
 
@@ -63,7 +76,8 @@ class SeedNodeService {
 
     // Fetch remote seed nodes or use defaults
     if (fetchRemote) {
-      return await fetchSeedNodes();
+      final result = await fetchSeedNodes();
+      return result.seedNodes;
     } else {
       return getDefaultSeedNodes();
     }

--- a/packages/komodo_defi_local_auth/lib/src/auth/auth_service_kdf_extension.dart
+++ b/packages/komodo_defi_local_auth/lib/src/auth/auth_service_kdf_extension.dart
@@ -179,7 +179,8 @@ extension KdfExtensions on KdfAuthService {
     }
 
     // Fetch seed nodes using the dedicated service
-    final seedNodes = await SeedNodeService.fetchSeedNodes();
+    final (seedNodes: seedNodes, netId: netId) =
+        await SeedNodeService.fetchSeedNodes();
 
     return KdfStartupConfig.generateWithDefaults(
       walletName: walletName,
@@ -190,6 +191,7 @@ extension KdfExtensions on KdfAuthService {
       enableHd: hdEnabled,
       allowWeakPassword: allowWeakPassword,
       seedNodes: seedNodes,
+      netid: netId,
     );
   }
 }

--- a/packages/komodo_defi_types/lib/src/seed_node/seed_node.dart
+++ b/packages/komodo_defi_types/lib/src/seed_node/seed_node.dart
@@ -5,6 +5,9 @@ class SeedNode {
   const SeedNode({
     required this.name,
     required this.host,
+    required this.type,
+    required this.wss,
+    required this.netId,
     required this.contact,
   });
 
@@ -17,11 +20,23 @@ class SeedNode {
   /// Contact information for the seed node
   final List<SeedNodeContact> contact;
 
+  /// The connection type of the seed node (e.g. domain or ip)
+  final String type;
+
+  /// Whether the seed node supports secure websockets
+  final bool wss;
+
+  /// The network identifier for the seed node
+  final int netId;
+
   /// Creates a [SeedNode] from a JSON map.
   factory SeedNode.fromJson(JsonMap json) {
     return SeedNode(
       name: json.value<String>('name'),
       host: json.value<String>('host'),
+      type: json.value<String>('type'),
+      wss: json.value<bool>('wss'),
+      netId: json.value<int>('netid'),
       contact: json
           .value<List<dynamic>>('contact')
           .cast<JsonMap>()
@@ -35,6 +50,9 @@ class SeedNode {
     return {
       'name': name,
       'host': host,
+      'type': type,
+      'wss': wss,
+      'netid': netId,
       'contact': contact.map((c) => c.toJson()).toList(),
     };
   }
@@ -50,14 +68,18 @@ class SeedNode {
     return other is SeedNode &&
         other.name == name &&
         other.host == host &&
+        other.type == type &&
+        other.wss == wss &&
+        other.netId == netId &&
         _listEquals(other.contact, contact);
   }
 
   @override
-  int get hashCode => Object.hash(name, host, contact);
+  int get hashCode => Object.hash(name, host, type, wss, netId, contact);
 
   @override
-  String toString() => 'SeedNode(name: $name, host: $host, contact: $contact)';
+  String toString() =>
+      'SeedNode(name: $name, host: $host, type: $type, wss: $wss, netId: $netId, contact: $contact)';
 
   /// Helper method to compare lists
   bool _listEquals<T>(List<T>? a, List<T>? b) {

--- a/packages/komodo_defi_types/test/seed_node_test.dart
+++ b/packages/komodo_defi_types/test/seed_node_test.dart
@@ -7,6 +7,9 @@ void main() {
       final json = {
         'name': 'seed-node-1',
         'host': 'seed01.kmdefi.net',
+        'type': 'domain',
+        'wss': true,
+        'netid': 8762,
         'contact': [
           {'email': 'admin@example.com'}
         ]
@@ -24,6 +27,9 @@ void main() {
       final seedNode = SeedNode(
         name: 'seed-node-2',
         host: 'seed02.kmdefi.net',
+        type: 'domain',
+        wss: true,
+        netId: 8762,
         contact: [
           SeedNodeContact(email: 'test@example.com'),
         ],
@@ -44,6 +50,9 @@ void main() {
         {
           'name': 'seed-node-1',
           'host': 'seed01.kmdefi.net',
+          'type': 'domain',
+          'wss': true,
+          'netid': 8762,
           'contact': [
             {'email': ''}
           ]
@@ -51,6 +60,9 @@ void main() {
         {
           'name': 'seed-node-2',
           'host': 'seed02.kmdefi.net',
+          'type': 'domain',
+          'wss': true,
+          'netid': 8762,
           'contact': [
             {'email': ''}
           ]
@@ -70,18 +82,27 @@ void main() {
       final seedNode1 = SeedNode(
         name: 'test',
         host: 'example.com',
+        type: 'domain',
+        wss: true,
+        netId: 8762,
         contact: [SeedNodeContact(email: 'test@example.com')],
       );
 
       final seedNode2 = SeedNode(
         name: 'test',
         host: 'example.com',
+        type: 'domain',
+        wss: true,
+        netId: 8762,
         contact: [SeedNodeContact(email: 'test@example.com')],
       );
 
       final seedNode3 = SeedNode(
         name: 'different',
         host: 'example.com',
+        type: 'domain',
+        wss: true,
+        netId: 8762,
         contact: [SeedNodeContact(email: 'test@example.com')],
       );
 


### PR DESCRIPTION
## Summary
- support new seed-nodes.json structure with netid
- filter out non-WSS nodes for web
- wire netid through service and config
- update examples and tests

## Testing
- `flutter pub get --offline`
- `dart format -l 80 .`
- `flutter analyze` *(fails: 2397 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685184e45f588326a0b8621d10843ac5