### PR TITLE
Fix get_enabled_coins v2 params issue

### DIFF
--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/activation/get_enabled_coins.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/activation/get_enabled_coins.dart
@@ -10,6 +10,16 @@ class GetEnabledCoinsRequest
     : super(method: 'get_enabled_coins', mmrpc: '2.0');
 
   @override
+  Map<String, dynamic> toJson() {
+    final json = super.toJson();
+    // Temporarily remove the params key until API bug is fixed:
+    // https://github.com/KomodoPlatform/komodo-defi-framework/issues/2498
+    json.remove('params');
+
+    return {...json, 'userpass': rpcPass};
+  }
+
+  @override
   GetEnabledCoinsResponse parseResponse(String responseBody) {
     return GetEnabledCoinsResponse.fromJson(jsonFromString(responseBody));
   }


### PR DESCRIPTION
## Summary
- prevent params key from being sent in v2 get_enabled_coins request
- include comment linking to https://github.com/KomodoPlatform/komodo-defi-framework/issues/2498

## Testing
- `dart format packages/komodo_defi_rpc_methods/lib/src/rpc_methods/activation/get_enabled_coins.dart`
- `flutter analyze` *(fails: 2406 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68596de1ac108326b5fdde383156061b