### PR TITLE
feat(ui): use spritemap for asset icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,8 @@ assets/config/coins_config.json
 assets/config/seed_nodes.json
 assets/config/coins_ci.json
 assets/coin_icons/
+packages/komodo_defi_framework/assets/coin_icons/spritemap.png
+packages/komodo_defi_framework/assets/coin_icons/spritemap.json
 
 # MacOS
 # Flutter-related

--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -63,7 +63,7 @@
     "coins": {
         "fetch_at_build_enabled": true,
         "update_commit_on_build": true,
-        "bundled_coins_repo_commit": "0fc30526f08de25d229ae8e14de4467a72720bc5",
+        "bundled_coins_repo_commit": "1cb2516eee7b78cf2e2de02e9bf8f8a566a25009",
         "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",
         "coins_repo_content_url": "https://komodoplatform.github.io/coins",
         "coins_repo_branch": "master",
@@ -71,7 +71,9 @@
         "mapped_files": {
             "assets/config/coins_config.json": "utils/coins_config_unfiltered.json",
             "assets/config/coins.json": "coins",
-            "assets/config/seed_nodes.json": "seed-nodes.json"
+            "assets/config/seed_nodes.json": "seed-nodes.json",
+            "assets/coin_icons/spritemap.png": "utils/spritemap.png",
+            "assets/coin_icons/spritemap.json": "utils/spritemap.json"
         },
         "mapped_folders": {
             "assets/coin_icons/png/": "icons"

--- a/packages/komodo_defi_framework/pubspec.yaml
+++ b/packages/komodo_defi_framework/pubspec.yaml
@@ -66,6 +66,8 @@ flutter:
   assets:
     - assets/config/
     - assets/coin_icons/png/
+    - assets/coin_icons/spritemap.png
+    - assets/coin_icons/spritemap.json
     - app_build/build_config.json
     
     - path: assets/.transformer_invoker

--- a/packages/komodo_defi_types/lib/komodo_defi_type_utils.dart
+++ b/packages/komodo_defi_types/lib/komodo_defi_type_utils.dart
@@ -11,3 +11,4 @@ export 'src/utils/live_data_builder.dart';
 export 'src/utils/mnemonic_validator.dart';
 export 'src/utils/retry_utils.dart';
 export 'src/utils/security_utils.dart';
+export 'src/utils/sprite_map.dart';

--- a/packages/komodo_defi_types/lib/src/utils/sprite_map.dart
+++ b/packages/komodo_defi_types/lib/src/utils/sprite_map.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+import 'dart:ui' as ui;
+
+import 'package:flutter/services.dart' show rootBundle;
+
+/// Holds sprite sheet image and icon coordinates.
+class SpriteMap {
+  SpriteMap({
+    required this.image,
+    required this.coordinates,
+    required this.iconSize,
+  });
+
+  /// Loaded sprite map image.
+  final ui.Image image;
+
+  /// Coordinate map for icons.
+  final Map<String, ui.Rect> coordinates;
+
+  /// Icon size as defined in metadata.
+  final int iconSize;
+
+  /// Loads a [SpriteMap] from asset paths.
+  static Future<SpriteMap> fromAssets({
+    required String imageAsset,
+    required String jsonAsset,
+  }) async {
+    final imageData = await rootBundle.load(imageAsset);
+    final codec = await ui.instantiateImageCodec(
+      imageData.buffer.asUint8List(),
+    );
+    final frame = await codec.getNextFrame();
+    final image = frame.image;
+
+    final jsonString = await rootBundle.loadString(jsonAsset);
+    final map = jsonDecode(jsonString) as Map<String, dynamic>;
+    final meta = map['metadata'] as Map<String, dynamic>;
+    final coordsRaw = map['coordinates'] as Map<String, dynamic>;
+
+    final coords = <String, ui.Rect>{};
+    for (final entry in coordsRaw.entries) {
+      final value = entry.value as Map<String, dynamic>;
+      coords[entry.key] = ui.Rect.fromLTWH(
+        (value['x'] as num).toDouble(),
+        (value['y'] as num).toDouble(),
+        (value['width'] as num).toDouble(),
+        (value['height'] as num).toDouble(),
+      );
+    }
+
+    return SpriteMap(
+      image: image,
+      coordinates: coords,
+      iconSize: meta['icon_size'] as int,
+    );
+  }
+
+  /// Returns the source rectangle for [id] or null if not found.
+  ui.Rect? rectFor(String id) => coordinates[id];
+}


### PR DESCRIPTION
## Summary
- add spritemap asset mappings
- load sprite map for AssetIcon
- expose SpriteMap helper in `komodo_defi_types`
- ignore spritemap assets in repo

## Testing
- `dart format packages/komodo_ui/lib/src/defi/asset/asset_icon.dart packages/komodo_defi_types/lib/komodo_defi_type_utils.dart packages/komodo_defi_types/lib/src/utils/sprite_map.dart`
- `flutter analyze lib/src/utils/sprite_map.dart lib/komodo_defi_type_utils.dart` (from `packages/komodo_defi_types`)
- `flutter analyze lib/src/defi/asset/asset_icon.dart` (from `packages/komodo_ui`)
- `flutter build web` *(fails: asset download)*
- `flutter build web`
- `flutter build web`

------
https://chatgpt.com/codex/tasks/task_e_68596f1ab7e08331bdc8036fa14c5148