### PR TITLE
fix(pubkey-manager): update missed PrivateKeyPolicy type comparisons

### DIFF
--- a/packages/komodo_defi_local_auth/lib/src/trezor/trezor_auth_service.dart
+++ b/packages/komodo_defi_local_auth/lib/src/trezor/trezor_auth_service.dart
@@ -159,7 +159,7 @@ class TrezorAuthService implements IAuthService {
     required AuthOptions options,
   }) async {
     // Throw exception if PrivateKeyPolicy is NOT trezor
-    if (options.privKeyPolicy != PrivateKeyPolicy.trezor) {
+    if (options.privKeyPolicy != const PrivateKeyPolicy.trezor()) {
       throw AuthException(
         'TrezorAuthService only supports Trezor private key policy',
         type: AuthExceptionType.generalAuthError,
@@ -226,7 +226,7 @@ class TrezorAuthService implements IAuthService {
     Mnemonic? mnemonic,
   }) async {
     // Throw exception if PrivateKeyPolicy is NOT trezor
-    if (options.privKeyPolicy != PrivateKeyPolicy.trezor) {
+    if (options.privKeyPolicy != const PrivateKeyPolicy.trezor()) {
       throw AuthException(
         'TrezorAuthService only supports Trezor private key policy',
         type: AuthExceptionType.generalAuthError,

--- a/packages/komodo_defi_types/lib/src/public_key/pubkey_strategy.dart
+++ b/packages/komodo_defi_types/lib/src/public_key/pubkey_strategy.dart
@@ -42,9 +42,9 @@ class PubkeyStrategyFactory {
       final privKeyPolicy = kdfUser.walletId.authOptions.privKeyPolicy;
 
       switch (privKeyPolicy) {
-        case PrivateKeyPolicy.trezor:
+        case const PrivateKeyPolicy.trezor():
           return TrezorHDWalletStrategy(kdfUser: kdfUser);
-        case PrivateKeyPolicy.contextPrivKey:
+        case const PrivateKeyPolicy.contextPrivKey():
           return ContextPrivKeyHDWalletStrategy(kdfUser: kdfUser);
       }
     }


### PR DESCRIPTION
Fixes failed activations due to incorrect type comparison in `pubkey_strategy.dart` (using previous Enum type), which would fall through to the legacy `SingleAddressStrategy`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of authentication and key management by refining how private key policies are checked during sign-in, registration, and public key strategy selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->