### PR TITLE
feat(asset): indicate signing support

### DIFF
--- a/packages/komodo_defi_sdk/example/lib/screens/asset_page.dart
+++ b/packages/komodo_defi_sdk/example/lib/screens/asset_page.dart
@@ -325,6 +325,7 @@ class _AssetHeaderState extends State<AssetHeader> {
         _currentUser?.authOptions.derivationMethod == DerivationMethod.hdWallet;
     final hasAddresses =
         widget.pubkeys != null && widget.pubkeys!.keys.isNotEmpty;
+    final supportsSigning = widget.asset.supportsMessageSigning;
 
     return Wrap(
       alignment: WrapAlignment.spaceEvenly,
@@ -357,14 +358,16 @@ class _AssetHeaderState extends State<AssetHeader> {
 
         Tooltip(
           message:
-              !hasAddresses
-                  ? 'No addresses available to sign with'
-                  : isHdWallet
-                  ? 'Will sign with the first address'
-                  : 'Sign a message with this address',
+              supportsSigning
+                  ? !hasAddresses
+                      ? 'No addresses available to sign with'
+                      : isHdWallet
+                      ? 'Will sign with the first address'
+                      : 'Sign a message with this address'
+                  : 'Message signing not supported for this asset',
           child: FilledButton.tonalIcon(
             onPressed:
-                _isSigningMessage || !hasAddresses
+                _isSigningMessage || !hasAddresses || !supportsSigning
                     ? null
                     : () => _showSignMessageDialog(context),
             icon: const Icon(Icons.edit_document),

--- a/packages/komodo_defi_types/lib/src/assets/asset.dart
+++ b/packages/komodo_defi_types/lib/src/assets/asset.dart
@@ -64,6 +64,12 @@ class Asset extends Equatable {
   final bool isWalletOnly;
   final String? signMessagePrefix;
 
+  /// Whether this asset supports message signing.
+  ///
+  /// Determined by the presence of the `sign_message_prefix` field in the
+  /// coin config.
+  bool get supportsMessageSigning => signMessagePrefix != null;
+
   JsonMap toJson() => {
         'protocol': protocol.toJson(),
         'id': id.toJson(),


### PR DESCRIPTION
## Summary
- expose `supportsMessageSigning` on `Asset`
- disable message signing button in the example for assets that don't support it

## Testing
- `flutter pub get --offline`
- `dart format packages/komodo_defi_types/lib/src/assets/asset.dart packages/komodo_defi_sdk/example/lib/screens/asset_page.dart`
- `flutter analyze` *(fails: multiple existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_6862796c9c6883269143d79ee298d7ae