### PR TITLE
feat(asset-manager): asset filter strategy based on current wallet

### DIFF
--- a/packages/komodo_coins/lib/komodo_coins.dart
+++ b/packages/komodo_coins/lib/komodo_coins.dart
@@ -1,6 +1,7 @@
 /// TODO! Library description
 library komodo_coins;
 
+export 'src/asset_filter.dart';
 export 'src/komodo_coins_base.dart';
 
 /// A Calculator.

--- a/packages/komodo_coins/lib/src/asset_filter.dart
+++ b/packages/komodo_coins/lib/src/asset_filter.dart
@@ -19,7 +19,7 @@ class NoAssetFilterStrategy implements AssetFilterStrategy {
 /// This includes assets that are not UTXO-based or EVM-based tokens.
 /// ETH, AVAX, BNB, FTM, etc. are excluded as they currently fail to
 /// activate on Trezor.
-/// ERC20, ARB20, and MATIC explicitly do not support Trezor via KDF
+/// ERC20, Arbitrum, and MATIC explicitly do not support Trezor via KDF
 /// at this time, so they are also excluded.
 class TrezorAssetFilterStrategy implements AssetFilterStrategy {
   const TrezorAssetFilterStrategy();
@@ -55,22 +55,6 @@ class EvmAssetFilterStrategy implements AssetFilterStrategy {
   const EvmAssetFilterStrategy();
 
   @override
-  bool shouldInclude(Asset asset, JsonMap coinConfig) {
-    final subClass = asset.protocol.subClass;
-    return subClass == CoinSubClass.avx20 ||
-        subClass == CoinSubClass.bep20 ||
-        subClass == CoinSubClass.ftm20 ||
-        subClass == CoinSubClass.matic ||
-        subClass == CoinSubClass.hrc20 ||
-        subClass == CoinSubClass.arbitrum ||
-        subClass == CoinSubClass.moonriver ||
-        subClass == CoinSubClass.moonbeam ||
-        subClass == CoinSubClass.ethereumClassic ||
-        subClass == CoinSubClass.ubiq ||
-        subClass == CoinSubClass.krc20 ||
-        subClass == CoinSubClass.ewt ||
-        subClass == CoinSubClass.hecoChain ||
-        subClass == CoinSubClass.rskSmartBitcoin ||
-        subClass == CoinSubClass.erc20;
-  }
+  bool shouldInclude(Asset asset, JsonMap coinConfig) =>
+      evmCoinSubClasses.contains(asset.protocol.subClass);
 }

--- a/packages/komodo_coins/lib/src/asset_filter.dart
+++ b/packages/komodo_coins/lib/src/asset_filter.dart
@@ -1,15 +1,24 @@
+import 'package:equatable/equatable.dart';
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 
 /// Strategy interface for filtering assets based on coin configuration.
-abstract class AssetFilterStrategy {
+abstract class AssetFilterStrategy extends Equatable {
+  const AssetFilterStrategy(this.name);
+
+  /// A unique name for the strategy used for comparison and caching.
+  final String name;
+
   /// Returns `true` if the asset should be included.
   bool shouldInclude(Asset asset, JsonMap coinConfig);
+
+  @override
+  List<Object?> get props => [name];
 }
 
 /// Default strategy that includes all assets.
-class NoAssetFilterStrategy implements AssetFilterStrategy {
-  const NoAssetFilterStrategy();
+class NoAssetFilterStrategy extends AssetFilterStrategy {
+  const NoAssetFilterStrategy() : super('none');
 
   @override
   bool shouldInclude(Asset asset, JsonMap coinConfig) => true;
@@ -21,8 +30,8 @@ class NoAssetFilterStrategy implements AssetFilterStrategy {
 /// activate on Trezor.
 /// ERC20, Arbitrum, and MATIC explicitly do not support Trezor via KDF
 /// at this time, so they are also excluded.
-class TrezorAssetFilterStrategy implements AssetFilterStrategy {
-  const TrezorAssetFilterStrategy();
+class TrezorAssetFilterStrategy extends AssetFilterStrategy {
+  const TrezorAssetFilterStrategy() : super('trezor');
 
   @override
   bool shouldInclude(Asset asset, JsonMap coinConfig) {
@@ -37,8 +46,8 @@ class TrezorAssetFilterStrategy implements AssetFilterStrategy {
 }
 
 /// Filters out assets that are not UTXO-based chains.
-class UtxoAssetFilterStrategy implements AssetFilterStrategy {
-  const UtxoAssetFilterStrategy();
+class UtxoAssetFilterStrategy extends AssetFilterStrategy {
+  const UtxoAssetFilterStrategy() : super('utxo');
 
   @override
   bool shouldInclude(Asset asset, JsonMap coinConfig) {
@@ -51,8 +60,8 @@ class UtxoAssetFilterStrategy implements AssetFilterStrategy {
 /// This includes various EVM-compatible chains like Ethereum, Binance, etc.
 /// This strategy is necessary for external wallets like Metamask or
 /// WalletConnect.
-class EvmAssetFilterStrategy implements AssetFilterStrategy {
-  const EvmAssetFilterStrategy();
+class EvmAssetFilterStrategy extends AssetFilterStrategy {
+  const EvmAssetFilterStrategy() : super('evm');
 
   @override
   bool shouldInclude(Asset asset, JsonMap coinConfig) =>

--- a/packages/komodo_coins/lib/src/asset_filter.dart
+++ b/packages/komodo_coins/lib/src/asset_filter.dart
@@ -1,0 +1,38 @@
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+
+/// Strategy interface for filtering assets based on coin configuration.
+abstract class AssetFilterStrategy {
+  /// Returns `true` if the asset should be included.
+  bool shouldInclude(Asset asset, JsonMap coinConfig);
+}
+
+/// Default strategy that includes all assets.
+class NoAssetFilterStrategy implements AssetFilterStrategy {
+  const NoAssetFilterStrategy();
+
+  @override
+  bool shouldInclude(Asset asset, JsonMap coinConfig) => true;
+}
+
+/// Filters assets that do not specify a `trezor_coin` field.
+class TrezorAssetFilterStrategy implements AssetFilterStrategy {
+  const TrezorAssetFilterStrategy();
+
+  @override
+  bool shouldInclude(Asset asset, JsonMap coinConfig) {
+    final field = coinConfig.valueOrNull<String>('trezor_coin');
+    return field != null && field.isNotEmpty;
+  }
+}
+
+/// Filters out assets that are not UTXO-based chains.
+class UtxoAssetFilterStrategy implements AssetFilterStrategy {
+  const UtxoAssetFilterStrategy();
+
+  @override
+  bool shouldInclude(Asset asset, JsonMap coinConfig) {
+    final subClass = asset.protocol.subClass;
+    return subClass == CoinSubClass.utxo || subClass == CoinSubClass.smartChain;
+  }
+}

--- a/packages/komodo_coins/lib/src/asset_filter.dart
+++ b/packages/komodo_coins/lib/src/asset_filter.dart
@@ -4,16 +4,16 @@ import 'package:komodo_defi_types/komodo_defi_types.dart';
 
 /// Strategy interface for filtering assets based on coin configuration.
 abstract class AssetFilterStrategy extends Equatable {
-  const AssetFilterStrategy(this.name);
+  const AssetFilterStrategy(this.strategyId);
 
-  /// A unique name for the strategy used for comparison and caching.
-  final String name;
+  /// A unique id for the strategy used for comparison and caching.
+  final String strategyId;
 
   /// Returns `true` if the asset should be included.
   bool shouldInclude(Asset asset, JsonMap coinConfig);
 
   @override
-  List<Object?> get props => [name];
+  List<Object?> get props => [strategyId];
 }
 
 /// Default strategy that includes all assets.

--- a/packages/komodo_coins/lib/src/komodo_coins_base.dart
+++ b/packages/komodo_coins/lib/src/komodo_coins_base.dart
@@ -18,6 +18,7 @@ class KomodoCoins {
   }
 
   Map<AssetId, Asset>? _assets;
+  final Map<String, Map<AssetId, Asset>> _filterCache = {};
 
   @mustCallSuper
   Future<void> init() async {
@@ -81,9 +82,10 @@ class KomodoCoins {
             coinData,
             knownIds: platformIds,
           ).map(
-            (id) => id.isChildAsset
-                ? AssetId.parse(coinData, knownIds: platformIds)
-                : id,
+            (id) =>
+                id.isChildAsset
+                    ? AssetId.parse(coinData, knownIds: platformIds)
+                    : id,
           );
 
           // Create Asset instance for each valid AssetId
@@ -124,6 +126,10 @@ class KomodoCoins {
     if (!isInitialized) {
       throw StateError('Assets have not been initialized. Call init() first.');
     }
+    final cacheKey = strategy.name;
+    final cached = _filterCache[cacheKey];
+    if (cached != null) return cached;
+
     final result = <AssetId, Asset>{};
     for (final entry in _assets!.entries) {
       final config = entry.value.protocol.config;
@@ -131,6 +137,7 @@ class KomodoCoins {
         result[entry.key] = entry.value;
       }
     }
+    _filterCache[cacheKey] = result;
     return result;
   }
 

--- a/packages/komodo_coins/lib/src/komodo_coins_base.dart
+++ b/packages/komodo_coins/lib/src/komodo_coins_base.dart
@@ -82,10 +82,9 @@ class KomodoCoins {
             coinData,
             knownIds: platformIds,
           ).map(
-            (id) =>
-                id.isChildAsset
-                    ? AssetId.parse(coinData, knownIds: platformIds)
-                    : id,
+            (id) => id.isChildAsset
+                ? AssetId.parse(coinData, knownIds: platformIds)
+                : id,
           );
 
           // Create Asset instance for each valid AssetId
@@ -126,7 +125,7 @@ class KomodoCoins {
     if (!isInitialized) {
       throw StateError('Assets have not been initialized. Call init() first.');
     }
-    final cacheKey = strategy.name;
+    final cacheKey = strategy.strategyId;
     final cached = _filterCache[cacheKey];
     if (cached != null) return cached;
 

--- a/packages/komodo_coins/lib/src/komodo_coins_base.dart
+++ b/packages/komodo_coins/lib/src/komodo_coins_base.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:komodo_coins/src/config_transform.dart';
+import 'package:komodo_coins/src/asset_filter.dart';
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 
@@ -76,8 +77,10 @@ class KomodoCoins {
 
         try {
           // Parse all possible AssetIds for this coin
-          final assetIds =
-              AssetId.parseAllTypes(coinData, knownIds: platformIds).map(
+          final assetIds = AssetId.parseAllTypes(
+            coinData,
+            knownIds: platformIds,
+          ).map(
             (id) => id.isChildAsset
                 ? AssetId.parse(coinData, knownIds: platformIds)
                 : id,
@@ -109,6 +112,26 @@ class KomodoCoins {
   static bool _hasNoParent(JsonMap coinData) {
     return !coinData.containsKey('parent_coin') ||
         coinData.valueOrNull<String>('parent_coin') == null;
+  }
+
+  /// Returns the assets filtered using the provided [strategy].
+  ///
+  /// This allows higher-level components, such as [AssetManager], to tailor
+  /// the visible asset list to the active authentication context. For example,
+  /// a hardware wallet may only support a subset of coins, which can be
+  /// enforced by supplying an appropriate [AssetFilterStrategy].
+  Map<AssetId, Asset> filteredAssets(AssetFilterStrategy strategy) {
+    if (!isInitialized) {
+      throw StateError('Assets have not been initialized. Call init() first.');
+    }
+    final result = <AssetId, Asset>{};
+    for (final entry in _assets!.entries) {
+      final config = entry.value.protocol.config;
+      if (strategy.shouldInclude(entry.value, config)) {
+        result[entry.key] = entry.value;
+      }
+    }
+    return result;
   }
 
   // Helper methods

--- a/packages/komodo_coins/test/asset_filter_test.dart
+++ b/packages/komodo_coins/test/asset_filter_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:komodo_coins/src/asset_filter.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+void main() {
+  group('Asset filtering', () {
+    final btcConfig = {
+      'coin': 'BTC',
+      'fname': 'Bitcoin',
+      'chain_id': 0,
+      'type': 'UTXO',
+      'protocol': {'type': 'UTXO'},
+      'is_testnet': false,
+      'trezor_coin': 'Bitcoin',
+    };
+
+    final ethConfig = {
+      'coin': 'ETH',
+      'fname': 'Ethereum',
+      'chain_id': 1,
+      'type': 'ERC-20',
+      'protocol': {
+        'type': 'ETH',
+        'protocol_data': {'chain_id': 1},
+      },
+      'nodes': [
+        {'url': 'https://rpc'},
+      ],
+      'swap_contract_address': '0xabc',
+      'fallback_swap_contract': '0xdef',
+    };
+
+    final btc = Asset.fromJson(btcConfig);
+    final eth = Asset.fromJson(ethConfig);
+
+    test('Trezor filter excludes assets missing trezor_coin', () {
+      const filter = TrezorAssetFilterStrategy();
+      expect(filter.shouldInclude(btc, btc.protocol.config), isTrue);
+      expect(filter.shouldInclude(eth, eth.protocol.config), isFalse);
+
+      final assets = {btc.id: btc, eth.id: eth};
+      final filtered = <AssetId, Asset>{};
+      for (final entry in assets.entries) {
+        if (filter.shouldInclude(entry.value, entry.value.protocol.config)) {
+          filtered[entry.key] = entry.value;
+        }
+      }
+
+      expect(filtered.containsKey(btc.id), isTrue);
+      expect(filtered.containsKey(eth.id), isFalse);
+    });
+
+    test('Trezor filter ignores empty trezor_coin field', () {
+      final cfg = Map<String, dynamic>.from(btcConfig)..['trezor_coin'] = '';
+      final asset = Asset.fromJson(cfg);
+      const filter = TrezorAssetFilterStrategy();
+      expect(filter.shouldInclude(asset, asset.protocol.config), isFalse);
+    });
+
+    test('UTXO filter only includes utxo assets', () {
+      const filter = UtxoAssetFilterStrategy();
+      expect(filter.shouldInclude(btc, btc.protocol.config), isTrue);
+      expect(filter.shouldInclude(eth, eth.protocol.config), isFalse);
+    });
+
+    test('UTXO filter accepts smartChain subclass', () {
+      final cfg = Map<String, dynamic>.from(btcConfig)
+        ..['type'] = 'SMART_CHAIN'
+        ..['protocol'] = {'type': 'UTXO'};
+      final asset = Asset.fromJson(cfg);
+      const filter = UtxoAssetFilterStrategy();
+      expect(asset.protocol.subClass, CoinSubClass.smartChain);
+      expect(filter.shouldInclude(asset, asset.protocol.config), isTrue);
+    });
+  });
+}

--- a/packages/komodo_defi_local_auth/lib/src/trezor/trezor_auth_service.dart
+++ b/packages/komodo_defi_local_auth/lib/src/trezor/trezor_auth_service.dart
@@ -208,7 +208,8 @@ class TrezorAuthService implements IAuthService {
     return users.firstWhereOrNull(
       (u) =>
           u.walletId.name == trezorWalletName &&
-          u.authOptions.privKeyPolicy == const PrivateKeyPolicy.trezor(),
+          u.walletId.authOptions.privKeyPolicy ==
+              const PrivateKeyPolicy.trezor(),
     );
   }
 

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/eth/task_enable_eth_init.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/eth/task_enable_eth_init.dart
@@ -31,6 +31,10 @@ class TaskEnableEthInit
   }
 
   @override
-  NewTaskResponse parse(Map<String, dynamic> json) =>
-      NewTaskResponse.parse(json);
+  NewTaskResponse parse(Map<String, dynamic> json) {
+    if (GeneralErrorResponse.isErrorResponse(json)) {
+      throw GeneralErrorResponse.parse(json);
+    }
+    return NewTaskResponse.parse(json);
+  }
 }

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/eth/task_enable_eth_init.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/eth/task_enable_eth_init.dart
@@ -29,4 +29,8 @@ class TaskEnableEthInit
     }
     return NewTaskResponse.parse(json);
   }
+
+  @override
+  NewTaskResponse parse(Map<String, dynamic> json) =>
+      NewTaskResponse.parse(json);
 }

--- a/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
@@ -65,6 +65,7 @@ class AssetManager implements IAssetProvider {
   late final AssetIdMap _orderedCoins;
   StreamSubscription<KdfUser?>? _authSubscription;
   bool _isDisposed = false;
+  AssetFilterStrategy? _currentFilterStrategy;
 
   /// NB: This cannot be used during initialization. This is a workaround
   /// to publicly expose the activation manager's activation methods.
@@ -95,9 +96,11 @@ class AssetManager implements IAssetProvider {
   }
 
   void _refreshCoins(AssetFilterStrategy strategy) {
+    if (_currentFilterStrategy?.name == strategy.name) return;
     _orderedCoins
       ..clear()
       ..addAll(_coins.filteredAssets(strategy));
+    _currentFilterStrategy = strategy;
   }
 
   /// Applies a new [strategy] for filtering available assets.

--- a/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
@@ -2,15 +2,14 @@
 
 import 'dart:async';
 import 'dart:collection';
+
 import 'package:flutter/foundation.dart' show ValueGetter;
 import 'package:komodo_coins/komodo_coins.dart';
-import 'package:komodo_coins/src/asset_filter.dart';
 import 'package:komodo_defi_local_auth/komodo_defi_local_auth.dart';
+import 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart';
 import 'package:komodo_defi_sdk/src/_internal_exports.dart';
 import 'package:komodo_defi_sdk/src/sdk/komodo_defi_sdk_config.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
-import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
-import 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart';
 
 typedef AssetIdMap = SplayTreeMap<AssetId, Asset>;
 
@@ -129,11 +128,18 @@ class AssetManager implements IAssetProvider {
   /// available assets to only those explicitly supported by that wallet.
   void _handleAuthStateChange(KdfUser? user) {
     if (_isDisposed) return;
-    final isTrezor = user?.authOptions.privKeyPolicy == PrivateKeyPolicy.trezor;
+
+    final isTrezor =
+        user?.authOptions.privKeyPolicy == const PrivateKeyPolicy.trezor();
+
+    // Trezor does not support all assets yet, so we apply a filter here
+    // to only show assets that are compatible with Trezor.
+    // WalletConnect and Metamask will require similar handling in the future.
     final strategy =
         isTrezor
             ? const TrezorAssetFilterStrategy()
             : const NoAssetFilterStrategy();
+
     setFilterStrategy(strategy);
   }
 

--- a/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
@@ -133,7 +133,8 @@ class AssetManager implements IAssetProvider {
     if (_isDisposed) return;
 
     final isTrezor =
-        user?.authOptions.privKeyPolicy == const PrivateKeyPolicy.trezor();
+        user?.walletId.authOptions.privKeyPolicy ==
+        const PrivateKeyPolicy.trezor();
 
     // Trezor does not support all assets yet, so we apply a filter here
     // to only show assets that are compatible with Trezor.

--- a/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
@@ -4,10 +4,13 @@ import 'dart:async';
 import 'dart:collection';
 import 'package:flutter/foundation.dart' show ValueGetter;
 import 'package:komodo_coins/komodo_coins.dart';
+import 'package:komodo_coins/src/asset_filter.dart';
 import 'package:komodo_defi_local_auth/komodo_defi_local_auth.dart';
 import 'package:komodo_defi_sdk/src/_internal_exports.dart';
 import 'package:komodo_defi_sdk/src/sdk/komodo_defi_sdk_config.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart';
 
 typedef AssetIdMap = SplayTreeMap<AssetId, Asset>;
 
@@ -37,6 +40,9 @@ typedef AssetIdMap = SplayTreeMap<AssetId, Asset>;
 /// // Get all activated assets
 /// final activeAssets = await assetManager.getActivatedAssets();
 /// ```
+///
+/// The manager listens to authentication changes to keep the available asset
+/// list in sync with the active wallet's capabilities.
 class AssetManager implements IAssetProvider {
   /// Creates a new instance of AssetManager.
   ///
@@ -48,7 +54,9 @@ class AssetManager implements IAssetProvider {
     this._config,
     this._customAssetHistory,
     this._activationManager,
-  );
+  ) {
+    _authSubscription = _auth.authStateChanges.listen(_handleAuthStateChange);
+  }
 
   final ApiClient _client;
   final KomodoDefiLocalAuth _auth;
@@ -56,6 +64,8 @@ class AssetManager implements IAssetProvider {
   final CustomAssetHistoryStorage _customAssetHistory;
   final KomodoCoins _coins = KomodoCoins();
   late final AssetIdMap _orderedCoins;
+  StreamSubscription<KdfUser?>? _authSubscription;
+  bool _isDisposed = false;
 
   /// NB: This cannot be used during initialization. This is a workaround
   /// to publicly expose the activation manager's activation methods.
@@ -80,9 +90,25 @@ class AssetManager implements IAssetProvider {
       return keyA.toString().compareTo(keyB.toString());
     });
 
-    _orderedCoins.addAll(_coins.all);
+    _refreshCoins(const NoAssetFilterStrategy());
 
     await _initializeCustomTokens();
+  }
+
+  void _refreshCoins(AssetFilterStrategy strategy) {
+    _orderedCoins
+      ..clear()
+      ..addAll(_coins.filteredAssets(strategy));
+  }
+
+  /// Applies a new [strategy] for filtering available assets.
+  ///
+  /// This is called whenever the authentication state changes so the
+  /// visible asset list always matches the capabilities of the active wallet.
+  void setFilterStrategy(AssetFilterStrategy strategy) {
+    if (_coins.isInitialized) {
+      _refreshCoins(strategy);
+    }
   }
 
   Future<void> _initializeCustomTokens() async {
@@ -95,6 +121,20 @@ class AssetManager implements IAssetProvider {
         _orderedCoins[customToken.id] = customToken;
       }
     }
+  }
+
+  /// Reacts to authentication changes by updating the active asset filter.
+  ///
+  /// When a hardware wallet such as Trezor is connected we limit the list of
+  /// available assets to only those explicitly supported by that wallet.
+  void _handleAuthStateChange(KdfUser? user) {
+    if (_isDisposed) return;
+    final isTrezor = user?.authOptions.privKeyPolicy == PrivateKeyPolicy.trezor;
+    final strategy =
+        isTrezor
+            ? const TrezorAssetFilterStrategy()
+            : const NoAssetFilterStrategy();
+    setFilterStrategy(strategy);
   }
 
   /// Returns an asset by its [AssetId], if available.
@@ -199,6 +239,7 @@ class AssetManager implements IAssetProvider {
   ///
   /// This is called automatically by the SDK when disposing.
   Future<void> dispose() async {
-    // No cleanup needed for now
+    _isDisposed = true;
+    await _authSubscription?.cancel();
   }
 }

--- a/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
@@ -96,7 +96,7 @@ class AssetManager implements IAssetProvider {
   }
 
   void _refreshCoins(AssetFilterStrategy strategy) {
-    if (_currentFilterStrategy?.name == strategy.name) return;
+    if (_currentFilterStrategy?.strategyId == strategy.strategyId) return;
     _orderedCoins
       ..clear()
       ..addAll(_coins.filteredAssets(strategy));

--- a/packages/komodo_defi_types/lib/src/coin_classes/coin_subclasses.dart
+++ b/packages/komodo_defi_types/lib/src/coin_classes/coin_subclasses.dart
@@ -275,3 +275,21 @@ enum CoinSubClass {
     }
   }
 }
+
+const Set<CoinSubClass> evmCoinSubClasses = {
+  CoinSubClass.avx20,
+  CoinSubClass.bep20,
+  CoinSubClass.ftm20,
+  CoinSubClass.matic,
+  CoinSubClass.hrc20,
+  CoinSubClass.arbitrum,
+  CoinSubClass.moonriver,
+  CoinSubClass.moonbeam,
+  CoinSubClass.ethereumClassic,
+  CoinSubClass.ubiq,
+  CoinSubClass.krc20,
+  CoinSubClass.ewt,
+  CoinSubClass.hecoChain,
+  CoinSubClass.rskSmartBitcoin,
+  CoinSubClass.erc20,
+};


### PR DESCRIPTION
## Summary

- Add asset filtering to `KomodoCoins` based on a filtering strategy provided by the caller (higher level `AssetManager` class in this case).
- Add auth-based filtering to `AssetManager` to only show UTXO and QTUM coins when in Trezor mode. 
- Add basic unit tests for the asset filter in `komodo_coins`

Note:
- Trezor remains filtered to UTXO, Smart chain, and QTUM.
- The `trezor_coin` field in the coins config is unfortunately not a reliable indicator of whether activation will succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced flexible asset filtering strategies to tailor asset visibility based on wallet compatibility and protocol subclass.
  * Asset lists dynamically update according to authentication state, including detection of Trezor hardware wallet usage.
  * Added support for filtering assets compatible with EVM-compatible wallets like Metamask and WalletConnect.
  * Enhanced asset management to apply filtering strategies reactively and cache filtered results for performance.

* **Bug Fixes**
  * Ensured asset lists update reactively when authentication state changes.

* **Tests**
  * Added comprehensive tests for asset filtering strategies to verify correct inclusion and exclusion of assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->