### PR TITLE
feat(core): use constant netid in seed node filtering

### DIFF
--- a/packages/komodo_coin_updates/lib/src/seed_node_updater.dart
+++ b/packages/komodo_coin_updates/lib/src/seed_node_updater.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
+import 'package:komodo_defi_types/constants.dart';
 
 /// Service responsible for fetching and managing seed nodes from remote sources.
 ///
@@ -33,14 +34,14 @@ class SeedNodeUpdater {
       final seedNodesJson = jsonListFromString(response.body);
       var seedNodes = SeedNode.fromJsonList(seedNodesJson);
 
-      // Extract netid from the first node if available
-      final netId = seedNodes.isNotEmpty ? seedNodes.first.netId : 8762;
+      // Filter nodes to the configured netId
+      seedNodes = seedNodes.where((e) => e.netId == kDefaultNetId).toList();
 
       if (filterForWeb && kIsWeb) {
         seedNodes = seedNodes.where((e) => e.wss).toList();
       }
 
-      return (seedNodes: seedNodes, netId: netId);
+      return (seedNodes: seedNodes, netId: kDefaultNetId);
     } catch (e) {
       debugPrint('Error fetching seed nodes: $e');
       throw Exception('Failed to fetch or process seed nodes: $e');

--- a/packages/komodo_defi_framework/lib/src/config/kdf_startup_config.dart
+++ b/packages/komodo_defi_framework/lib/src/config/kdf_startup_config.dart
@@ -8,6 +8,7 @@ import 'package:komodo_coins/komodo_coins.dart';
 import 'package:komodo_defi_framework/src/config/seed_node_validator.dart';
 import 'package:komodo_defi_framework/src/services/seed_node_service.dart'
     show SeedNodeService;
+import 'package:komodo_defi_types/constants.dart';
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
@@ -82,7 +83,7 @@ class KdfStartupConfig {
     int? hdAccountId,
     bool allowWeakPassword = false,
     int rpcPort = 7783,
-    int netid = 8762,
+    int netid = kDefaultNetId,
     String gui = 'komodo-defi-flutter-auth',
     bool https = false,
     bool rpcLocalOnly = true,

--- a/packages/komodo_defi_framework/lib/src/services/seed_node_service.dart
+++ b/packages/komodo_defi_framework/lib/src/services/seed_node_service.dart
@@ -2,6 +2,7 @@ import 'package:komodo_coin_updates/komodo_coin_updates.dart';
 import 'package:flutter/foundation.dart';
 import 'package:komodo_defi_framework/src/config/kdf_logging_config.dart';
 import 'package:komodo_defi_framework/src/config/seed_node_validator.dart';
+import 'package:komodo_defi_types/constants.dart';
 
 /// Service class responsible for fetching and managing seed nodes.
 ///
@@ -36,7 +37,7 @@ class SeedNodeService {
       }
       return (
         seedNodes: getDefaultSeedNodes(),
-        netId: 8762,
+        netId: kDefaultNetId,
       );
     }
   }

--- a/packages/komodo_defi_types/lib/komodo_defi_types.dart
+++ b/packages/komodo_defi_types/lib/komodo_defi_types.dart
@@ -5,6 +5,8 @@
 /// More dartdocs go here.
 library;
 
+export 'src/constants.dart';
+
 export 'src/api/api_client.dart';
 export 'src/assets/asset.dart';
 export 'src/assets/asset_id.dart';

--- a/packages/komodo_defi_types/lib/src/constants.dart
+++ b/packages/komodo_defi_types/lib/src/constants.dart
@@ -1,0 +1,5 @@
+/// Shared constants used across the Komodo DeFi SDK packages.
+library komodo_defi_types.constants;
+
+/// Default network identifier used by seed nodes and framework configuration.
+const int kDefaultNetId = 8762;


### PR DESCRIPTION
## Summary
- centralize `netId` in `kDefaultNetId`
- filter seed nodes using the constant
- use the constant in fallback logic and startup defaults

## Testing
- `dart format packages/komodo_defi_types/lib/src/constants.dart packages/komodo_defi_types/lib/komodo_defi_types.dart packages/komodo_coin_updates/lib/src/seed_node_updater.dart packages/komodo_defi_framework/lib/src/services/seed_node_service.dart packages/komodo_defi_framework/lib/src/config/kdf_startup_config.dart`
- `flutter analyze` *(fails: The name 'CounterView' isn't a class, etc.)*
- `flutter pub get --offline`

------
https://chatgpt.com/codex/tasks/task_e_686402c66d88832681240858245ce9aa