### PR TITLE
Fix asset overlay for child assets

### DIFF
--- a/packages/komodo_defi_types/lib/src/assets/asset_id.dart
+++ b/packages/komodo_defi_types/lib/src/assets/asset_id.dart
@@ -127,7 +127,7 @@ class AssetId extends Equatable {
       };
 
   @override
-  List<Object?> get props => [id, subClass.formatted];
+  List<Object?> get props => [id, subClass.formatted, chainId.formattedChainId];
 
   @override
   String toString() =>

--- a/packages/komodo_ui/lib/src/defi/asset/asset_logo.dart
+++ b/packages/komodo_ui/lib/src/defi/asset/asset_logo.dart
@@ -62,9 +62,12 @@ class AssetLogo extends StatelessWidget {
     final resolvedTicker = _legacyTicker;
     final resolvedSubClass = asset?.protocol.subClass ?? assetId?.subClass;
 
-    final protocolTicker = resolvedSubClass?.iconTicker;
-    final shouldShowProtocolIcon =
-        resolvedSubClass != null && resolvedSubClass != CoinSubClass.utxo;
+    final isChildAsset = resolvedId?.isChildAsset ?? false;
+
+    // Use the parent coin ticker for child assets so that token logos display
+    // the network they belong to (e.g. ETH for ERC20 tokens).
+    final protocolTicker = isChildAsset ? resolvedId?.parentId?.id : null;
+    final shouldShowProtocolIcon = isChildAsset && protocolTicker != null;
 
     final mainIcon =
         resolvedId != null


### PR DESCRIPTION
Solves: https://github.com/KomodoPlatform/komodo-wallet/issues/2626

This pull request introduces enhancements to asset handling and display logic in the Komodo codebase. The changes primarily improve the identification and representation of assets, including support for child asset relationships and chain-specific formatting.

### Asset Identification Enhancements:

* [`packages/komodo_defi_types/lib/src/assets/asset_id.dart`](diffhunk://#diff-99610277540b29ab3e047cabc297437934132d6e71d63d82e4d5c7e43fcfba20L130-R130): Updated the `props` getter in the `AssetId` class to include `chainId.formattedChainId`, ensuring chain-specific formatting is part of equality checks.

### Asset Display Logic Improvements:

* [`packages/komodo_ui/lib/src/defi/asset/asset_logo.dart`](diffhunk://#diff-f4762f83485ef78679336c0337376d787ff2469bc0147b6b3b02d53b677f9e4eL65-R70): Modified the `AssetLogo` widget to handle child assets more effectively. It now uses the parent coin ticker for child assets, allowing token logos to display the network they belong to (e.g., ETH for ERC20 tokens). Additionally, updated the logic for determining whether to show protocol icons based on child asset relationships.