### PR TITLE
fix(local_auth): ensure kdf running before wallet deletion

### DIFF
--- a/packages/komodo_defi_local_auth/lib/src/auth/auth_service.dart
+++ b/packages/komodo_defi_local_auth/lib/src/auth/auth_service.dart
@@ -333,6 +333,7 @@ class KdfAuthService implements IAuthService {
     required String walletName,
     required String password,
   }) async {
+    await _ensureKdfRunning();
     return _runReadOperation(() async {
       try {
         await _client.rpc.wallet.deleteWallet(


### PR DESCRIPTION
## Summary
- start KDF in no-auth mode when deleting a wallet

## Testing
- `dart format packages/komodo_defi_local_auth/lib/src/auth/auth_service.dart`
- `flutter pub get --offline`
- `flutter analyze packages/komodo_defi_local_auth/lib/src/auth/auth_service.dart`


------
https://chatgpt.com/codex/tasks/task_e_6867f893db188326989b9ee4eaf66631