### PR TITLE
Update asset_page to use streamed address creation

### DIFF
--- a/packages/komodo_defi_sdk/example/lib/screens/asset_page.dart
+++ b/packages/komodo_defi_sdk/example/lib/screens/asset_page.dart
@@ -47,8 +47,7 @@ class _AssetPageState extends State<AssetPage> {
   Future<void> _generateNewAddress() async {
     setState(() => _isLoading = true);
     try {
-      final stream =
-          _sdk.pubkeys.createNewPubkeyStream(widget.asset).asBroadcastStream();
+      final stream = _sdk.pubkeys.createNewPubkeyStream(widget.asset);
 
       final newPubkey = await showDialog<PubkeyInfo>(
         context: context,
@@ -750,6 +749,12 @@ class _NewAddressDialogState extends State<_NewAddressDialog> {
           Text(message, textAlign: TextAlign.center),
         ],
       ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+      ],
     );
   }
 }

--- a/packages/komodo_defi_sdk/example/lib/screens/asset_page.dart
+++ b/packages/komodo_defi_sdk/example/lib/screens/asset_page.dart
@@ -47,10 +47,20 @@ class _AssetPageState extends State<AssetPage> {
   Future<void> _generateNewAddress() async {
     setState(() => _isLoading = true);
     try {
-      final newPubkey = await _sdk.pubkeys.createNewPubkey(widget.asset);
-      setState(() {
-        _pubkeys?.keys.add(newPubkey);
-      });
+      final stream =
+          _sdk.pubkeys.createNewPubkeyStream(widget.asset).asBroadcastStream();
+
+      final newPubkey = await showDialog<PubkeyInfo>(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => _NewAddressDialog(stream: stream),
+      );
+
+      if (newPubkey != null) {
+        setState(() {
+          _pubkeys?.keys.add(newPubkey);
+        });
+      }
     } catch (e) {
       setState(() => _error = e.toString());
     } finally {
@@ -653,5 +663,93 @@ class __TransactionsSectionState extends State<_TransactionsSection> {
       print('FAILED TO FETCH TXs');
       print(e);
     }
+  }
+}
+
+class _NewAddressDialog extends StatefulWidget {
+  const _NewAddressDialog({required this.stream});
+
+  final Stream<NewAddressState> stream;
+
+  @override
+  State<_NewAddressDialog> createState() => _NewAddressDialogState();
+}
+
+class _NewAddressDialogState extends State<_NewAddressDialog> {
+  late final StreamSubscription<NewAddressState> _subscription;
+  NewAddressState? _state;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscription = widget.stream.listen((state) {
+      setState(() => _state = state);
+      if (state.status == NewAddressStatus.completed) {
+        Navigator.of(context).pop(state.address);
+      } else if (state.status == NewAddressStatus.error ||
+          state.status == NewAddressStatus.cancelled) {
+        Navigator.of(context).pop(null);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _subscription.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = _state;
+
+    String message;
+    if (state == null) {
+      message = 'Initializing...';
+    } else {
+      switch (state.status) {
+        case NewAddressStatus.initializing:
+        case NewAddressStatus.processing:
+        case NewAddressStatus.waitingForDevice:
+        case NewAddressStatus.waitingForDeviceConfirmation:
+        case NewAddressStatus.pinRequired:
+        case NewAddressStatus.passphraseRequired:
+          message = state.message ?? 'Processing...';
+          break;
+        case NewAddressStatus.confirmAddress:
+          message = 'Confirm the address on your device';
+          break;
+        case NewAddressStatus.completed:
+          message = 'Completed';
+          break;
+        case NewAddressStatus.error:
+          message = state.error ?? 'Error';
+          break;
+        case NewAddressStatus.cancelled:
+          message = 'Cancelled';
+          break;
+      }
+    }
+
+    final showAddress = state?.status == NewAddressStatus.confirmAddress;
+
+    return AlertDialog(
+      title: const Text('Generating Address'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (showAddress)
+            SelectableText(state?.expectedAddress ?? '')
+          else
+            const SizedBox(
+              width: 32,
+              height: 32,
+              child: CircularProgressIndicator(),
+            ),
+          const SizedBox(height: 16),
+          Text(message, textAlign: TextAlign.center),
+        ],
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- use `createNewPubkeyStream` when generating addresses
- show progress dialog handling all `NewAddressState` statuses
- display expected address when confirmation is required

## Testing
- `dart analyze`
- `dart pub get`
- `dart test` *(fails: Could not find package `test` or file `test:test`)*

------
https://chatgpt.com/codex/tasks/task_e_6867ed6ce014833198804336bbf419cb