### PR TITLE
Refactor logging setup

### DIFF
--- a/packages/komodo_defi_framework/lib/src/config/seed_node_validator.dart
+++ b/packages/komodo_defi_framework/lib/src/config/seed_node_validator.dart
@@ -1,8 +1,10 @@
 import 'package:komodo_defi_framework/src/config/kdf_logging_config.dart';
 import 'package:komodo_defi_framework/src/exceptions/kdf_exception.dart';
+import 'package:logging/logging.dart';
 
 /// Helper class to validate seed node configurations
 class SeedNodeValidator {
+  static final _log = Logger('SeedNodeValidator');
   /// Validates the seed node configuration
   ///
   /// Throws [KdfException] if the configuration is invalid
@@ -23,8 +25,10 @@ class SeedNodeValidator {
     // If P2P is disabled, no need for further validation
     if (disableP2p ?? false) {
       if (KdfLoggingConfig.verboseLogging) {
-        print('WARN P2P is disabled. Features that require a P2P network '
-            '(like swaps, peer health checks, etc.) will not work.');
+        _log.warning(
+          'P2P is disabled. Features that require a P2P network '
+          '(like swaps, peer health checks, etc.) will not work.',
+        );
       }
       return;
     }
@@ -58,8 +62,10 @@ class SeedNodeValidator {
     // Warning about future requirements - updated to be more explicit
     if (seedNodes == null || seedNodes.isEmpty) {
       if (KdfLoggingConfig.verboseLogging) {
-        print('WARN From v2.5.0-beta, there will be no default seed nodes, '
-            'and the seednodes parameter will be required unless disable_p2p is set to true.');
+        _log.warning(
+          'From v2.5.0-beta, there will be no default seed nodes, and the '
+          'seednodes parameter will be required unless disable_p2p is set to true.',
+        );
       }
     }
   }

--- a/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
+++ b/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
@@ -275,9 +275,9 @@ class KdfOperationsWasm implements IKdfOperations {
     if (KdfLoggingConfig.debugLogging) {
       try {
         final stringified = jsResponse.dartify().toString();
-        _log('Raw JS response: $stringified');
+        _log.finer('Raw JS response: $stringified');
       } catch (e) {
-        _log('Raw JS response: $jsResponse (stringify failed: $e)');
+        _log.finer('Raw JS response: $jsResponse (stringify failed: $e)');
       }
     }
     return jsResponse as js_interop.JSObject;

--- a/packages/komodo_defi_framework/lib/src/services/seed_node_service.dart
+++ b/packages/komodo_defi_framework/lib/src/services/seed_node_service.dart
@@ -3,12 +3,14 @@ import 'package:flutter/foundation.dart';
 import 'package:komodo_defi_framework/src/config/kdf_logging_config.dart';
 import 'package:komodo_defi_framework/src/config/seed_node_validator.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
+import 'package:logging/logging.dart';
 
 /// Service class responsible for fetching and managing seed nodes.
 ///
 /// This class follows the Single Responsibility Principle by focusing
 /// solely on seed node acquisition and management.
 class SeedNodeService {
+  static final _log = Logger('SeedNodeService');
   /// Fetches seed nodes from the remote configuration with fallback to defaults.
   ///
   /// This method attempts to fetch the latest seed nodes from the Komodo Platform
@@ -32,8 +34,8 @@ class SeedNodeService {
       );
     } catch (e) {
       if (KdfLoggingConfig.verboseLogging) {
-        print('WARN Failed to fetch seed nodes from remote: $e');
-        print('WARN Falling back to default seed nodes');
+        _log.warning('Failed to fetch seed nodes from remote: $e');
+        _log.warning('Falling back to default seed nodes');
       }
       return (
         seedNodes: getDefaultSeedNodes(),


### PR DESCRIPTION
## Summary
- remove internal logging configuration from `KomodoDefiFramework`
- add stream listener without changing root log level
- convert print statements in seed node modules to use `logging` package
- fix debug log lines in WASM operations

## Testing
- `dart format -o none packages/komodo_defi_framework/lib/komodo_defi_framework.dart packages/komodo_defi_framework/lib/src/config/seed_node_validator.dart packages/komodo_defi_framework/lib/src/services/seed_node_service.dart packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart`
- `dart test` *(fails: Could not find package `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686d55e90f188331945a0652599993b7