### PR TITLE
fix(staking): support qtum address field

### DIFF
--- a/packages/komodo_defi_types/lib/src/staking/staking_types.dart
+++ b/packages/komodo_defi_types/lib/src/staking/staking_types.dart
@@ -7,29 +7,36 @@ import 'package:komodo_defi_types/komodo_defi_types.dart';
 class StakingDetails extends Equatable implements RpcRequestParams {
   const StakingDetails({
     required this.type,
-    required this.validatorAddress,
+    this.validatorAddress,
+    this.address,
     this.amount,
-  });
+  }) : assert(
+          validatorAddress != null || address != null,
+          'Either validatorAddress or address must be provided',
+        );
 
   factory StakingDetails.fromJson(JsonMap json) => StakingDetails(
         type: json.value<String>('type'),
-        validatorAddress: json.value<String>('validator_address'),
+        validatorAddress: json.valueOrNull<String>('validator_address'),
+        address: json.valueOrNull<String>('address'),
         amount: json.valueOrNull<String>('amount'),
       );
 
   final String type;
-  final String validatorAddress;
+  final String? validatorAddress;
+  final String? address;
   final String? amount;
 
   @override
   JsonMap toRpcParams() => {
         'type': type,
-        'validator_address': validatorAddress,
+        if (validatorAddress != null) 'validator_address': validatorAddress,
+        if (address != null) 'address': address,
         if (amount != null) 'amount': amount,
       };
 
   @override
-  List<Object?> get props => [type, validatorAddress, amount];
+  List<Object?> get props => [type, validatorAddress, address, amount];
 }
 
 /// Details for claiming staking rewards


### PR DESCRIPTION
## Summary
- allow `address` field when delegating/undelegating staking for Qtum

## Testing
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_687169e1a7e483268d9c9706b07ad426