### PR TITLE
Allow customizing SourceAddressField widgets

### DIFF
--- a/packages/komodo_ui/lib/src/defi/withdraw/source_address_field.dart
+++ b/packages/komodo_ui/lib/src/defi/withdraw/source_address_field.dart
@@ -12,6 +12,8 @@ class SourceAddressField extends StatelessWidget {
     this.onRetry,
     this.isLoading = false,
     this.showBalanceIndicator = true,
+    this.title,
+    this.content,
     super.key,
   });
 
@@ -23,6 +25,8 @@ class SourceAddressField extends StatelessWidget {
   final VoidCallback? onRetry;
   final bool isLoading;
   final bool showBalanceIndicator;
+  final Widget? title;
+  final Widget? content;
 
   @override
   Widget build(BuildContext context) {
@@ -48,12 +52,13 @@ class SourceAddressField extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Text(
-              'Source Address',
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
-            ),
+            title ??
+                Text(
+                  'Source Address',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
             if (pubkeys!.keys.length > 1)
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -73,30 +78,31 @@ class SourceAddressField extends StatelessWidget {
           ],
         ),
         const SizedBox(height: 8),
-        AddressSelectInput(
-          addresses: pubkeys!.keys,
-          selectedAddress: selectedAddress,
-          onAddressSelected: onChanged,
-          assetName: asset.id.name,
-          hint: 'Choose source address',
-          onCopied: (address) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: const Row(
-                  children: [
-                    Icon(Icons.check_circle, color: Colors.white, size: 16),
-                    SizedBox(width: 8),
-                    Text('Address copied to clipboard'),
-                  ],
-                ),
-                behavior: SnackBarBehavior.floating,
-                width: 280,
-                backgroundColor: theme.colorScheme.primary,
-              ),
-            );
-          },
-          verified: _isAddressVerified,
-        ),
+        content ??
+            AddressSelectInput(
+              addresses: pubkeys!.keys,
+              selectedAddress: selectedAddress,
+              onAddressSelected: onChanged,
+              assetName: asset.id.name,
+              hint: 'Choose source address',
+              onCopied: (address) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: const Row(
+                      children: [
+                        Icon(Icons.check_circle, color: Colors.white, size: 16),
+                        SizedBox(width: 8),
+                        Text('Address copied to clipboard'),
+                      ],
+                    ),
+                    behavior: SnackBarBehavior.floating,
+                    width: 280,
+                    backgroundColor: theme.colorScheme.primary,
+                  ),
+                );
+              },
+              verified: _isAddressVerified,
+            ),
         if (selectedAddress != null && showBalanceIndicator) ...[
           const SizedBox(height: 12),
           _BalanceIndicator(


### PR DESCRIPTION
## Summary
- extend `SourceAddressField` constructor with `title` and `content` widget parameters
- use the injected widgets when present instead of the default header or `AddressSelectInput`

## Testing
- `dart format packages/komodo_ui/lib/src/defi/withdraw/source_address_field.dart`
- `flutter analyze packages/komodo_ui/lib/src/defi/withdraw/source_address_field.dart`
- `flutter build web` (run twice) in `packages/komodo_defi_sdk/example`

------
https://chatgpt.com/codex/tasks/task_e_6876a2c37f04833190f8be168c60ec72