### PR TITLE
fix(withdraw): revert temporary IBC channel type workaround

### DIFF
--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/withdrawal/withdraw_request.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/withdrawal/withdraw_request.dart
@@ -38,8 +38,7 @@ class WithdrawRequest
   final WithdrawalSource? from;
   final String? memo;
   final bool max;
-  // TODO: update to `int?` when the KDF changes in v2.5.0-beta
-  final String? ibcSourceChannel;
+  final int? ibcSourceChannel;
 
   @override
   Map<String, dynamic> toJson() => {
@@ -52,9 +51,6 @@ class WithdrawRequest
       if (fee != null) 'fee': fee!.toJson(),
       if (from != null) 'from': from!.toRpcParams(),
       if (memo != null) 'memo': memo,
-      //TODO! Migrate breaking changes when the ibc_source_channel is
-      // changed to a numeric type in KDF.
-      // https://github.com/KomodoPlatform/komodo-defi-framework/pull/2298#discussion_r2034825504
       if (ibcSourceChannel != null) 'ibc_source_channel': ibcSourceChannel,
     },
   };

--- a/packages/komodo_defi_sdk/example/lib/screens/withdrawal_page.dart
+++ b/packages/komodo_defi_sdk/example/lib/screens/withdrawal_page.dart
@@ -36,7 +36,6 @@ class _WithdrawalScreenState extends State<WithdrawalScreen> {
   WithdrawalPreview? _preview;
   String? _error;
   bool _isIbcTransfer = false;
-  final bool _isLoadingAddresses = false;
 
   AddressValidation? _addressValidation;
   final _validationDebouncer = Debouncer();
@@ -113,7 +112,8 @@ class _WithdrawalScreenState extends State<WithdrawalScreen> {
         memo: _memoController.text.isEmpty ? null : _memoController.text,
         isMax: _isMaxAmount,
         ibcTransfer: _isIbcTransfer ? true : null,
-        ibcSourceChannel: _isIbcTransfer ? _ibcChannelController.text : null,
+        ibcSourceChannel:
+            _isIbcTransfer ? int.tryParse(_ibcChannelController.text) : null,
       );
 
       final preview = await _sdk.withdrawals.previewWithdrawal(params);
@@ -325,17 +325,15 @@ class _WithdrawalScreenState extends State<WithdrawalScreen> {
                     controller: _ibcChannelController,
                     decoration: const InputDecoration(
                       labelText: 'IBC Channel',
-                      hintText: 'Enter IBC channel ID (e.g. channel-141)',
+                      hintText: 'Enter IBC channel ID (e.g. 141)',
                     ),
-                    validator: (value) {
-                      if (value?.isEmpty == true) {
-                        return 'Please enter IBC channel';
-                      }
-                      if (!RegExp(r'^channel-\d+$').hasMatch(value!)) {
-                        return 'Channel must be in format "channel-" followed by a number';
-                      }
-                      return null;
-                    },
+                    keyboardType: TextInputType.number,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    validator:
+                        (value) =>
+                            value?.isEmpty == true
+                                ? 'Please enter IBC channel number'
+                                : null,
                   ),
                 ],
               ],

--- a/packages/komodo_defi_types/lib/src/withdrawal/withdrawal_types.dart
+++ b/packages/komodo_defi_types/lib/src/withdrawal/withdrawal_types.dart
@@ -167,7 +167,7 @@ class WithdrawParameters extends Equatable {
   final WithdrawalSource? from;
   final String? memo;
   final bool? ibcTransfer;
-  final String? ibcSourceChannel;
+  final int? ibcSourceChannel;
   final bool? isMax;
 
   JsonMap toJson() => {


### PR DESCRIPTION
Reverts the temporary IBC channel workaround in #63 by changing the expected type back to `int`