### PR TITLE
Fix staking info_details bug

### DIFF
--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/staking/staking_rpc_namespace.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/staking/staking_rpc_namespace.dart
@@ -227,23 +227,43 @@ class StakingTxResponse extends BaseResponse {
 }
 
 class QueryDelegationsResponse extends BaseResponse {
-  QueryDelegationsResponse({required super.mmrpc, required this.delegations});
+  QueryDelegationsResponse({
+    required super.mmrpc,
+    this.delegations,
+    this.stakingInfosDetails,
+  });
 
-  factory QueryDelegationsResponse.parse(Map<String, dynamic> json) =>
-      QueryDelegationsResponse(
-        mmrpc: json.value<String>('mmrpc'),
-        delegations:
-            (json.value<JsonMap>('result')['delegations'] as List)
-                .map((e) => DelegationInfo.fromJson(e as JsonMap))
-                .toList(),
-      );
+  factory QueryDelegationsResponse.parse(Map<String, dynamic> json) {
+    final result = json.value<JsonMap>('result');
+    return QueryDelegationsResponse(
+      mmrpc: json.value<String>('mmrpc'),
+      delegations:
+          result.containsKey('delegations')
+              ? (result['delegations'] as List)
+                  .map((e) => DelegationInfo.fromJson(e as JsonMap))
+                  .toList()
+              : null,
+      stakingInfosDetails:
+          result.containsKey('staking_infos_details')
+              ? StakingInfosDetails.fromJson(
+                result.value<JsonMap>('staking_infos_details'),
+              )
+              : null,
+    );
+  }
 
-  final List<DelegationInfo> delegations;
+  final List<DelegationInfo>? delegations;
+  final StakingInfosDetails? stakingInfosDetails;
 
   @override
   Map<String, dynamic> toJson() => {
     'mmrpc': mmrpc,
-    'result': {'delegations': delegations.map((e) => e.toJson()).toList()},
+    'result': {
+      if (delegations != null)
+        'delegations': delegations!.map((e) => e.toJson()).toList(),
+      if (stakingInfosDetails != null)
+        'staking_infos_details': stakingInfosDetails!.toJson(),
+    },
   };
 }
 

--- a/packages/komodo_defi_sdk/example/lib/screens/staking_page.dart
+++ b/packages/komodo_defi_sdk/example/lib/screens/staking_page.dart
@@ -27,7 +27,10 @@ class _StakingScreenState extends State<StakingScreen> {
     setState(() => _loading = true);
     final sdk = context.read<KomodoDefiSdk>();
     try {
-      final infos = await sdk.staking.queryDelegations(widget.asset.id.name);
+      final infos = await sdk.staking.queryDelegations(
+        widget.asset.id.name,
+        infoDetails: const StakingInfoDetails(type: 'Cosmos'),
+      );
       setState(() => _delegations = infos);
     } catch (e) {
       setState(() => _error = e.toString());

--- a/packages/komodo_defi_sdk/lib/src/staking/staking_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/staking/staking_manager.dart
@@ -53,14 +53,14 @@ class StakingManager {
 
   Future<List<DelegationInfo>> queryDelegations(
     String coin, {
-    StakingInfoDetails? infoDetails,
+    required StakingInfoDetails infoDetails,
   }) async {
     await _ensureActivated(coin);
     final response = await _client.rpc.staking.queryDelegations(
       coin: coin,
       infoDetails: infoDetails,
     );
-    return response.delegations;
+    return response.delegations ?? const [];
   }
 
   Future<List<OngoingUndelegation>> queryOngoingUndelegations(

--- a/packages/komodo_defi_types/lib/src/staking/staking_types.dart
+++ b/packages/komodo_defi_types/lib/src/staking/staking_types.dart
@@ -197,3 +197,45 @@ class ValidatorInfo extends Equatable {
   @override
   List<Object?> get props => [data];
 }
+
+/// Summary of staking information for QTUM coins
+class StakingInfosDetails extends Equatable {
+  const StakingInfosDetails({
+    required this.type,
+    required this.amount,
+    this.staker,
+    required this.amIStaking,
+    required this.isStakingSupported,
+  });
+
+  factory StakingInfosDetails.fromJson(JsonMap json) => StakingInfosDetails(
+        type: json.value<String>('type'),
+        amount: json.value<String>('amount'),
+        staker: json.valueOrNull<String>('staker'),
+        amIStaking: json.value<bool>('am_i_staking'),
+        isStakingSupported: json.value<bool>('is_staking_supported'),
+      );
+
+  final String type;
+  final String amount;
+  final String? staker;
+  final bool amIStaking;
+  final bool isStakingSupported;
+
+  JsonMap toJson() => {
+        'type': type,
+        'amount': amount,
+        if (staker != null) 'staker': staker,
+        'am_i_staking': amIStaking,
+        'is_staking_supported': isStakingSupported,
+      };
+
+  @override
+  List<Object?> get props => [
+        type,
+        amount,
+        staker,
+        amIStaking,
+        isStakingSupported,
+      ];
+}


### PR DESCRIPTION
## Summary
- add `StakingInfosDetails` data structure
- parse Cosmos and Qtum staking results
- require `infoDetails` for staking queries
- update example to use `StakingInfoDetails`

## Testing
- `dart format packages/komodo_defi_types/lib/src/staking/staking_types.dart packages/komodo_defi_rpc_methods/lib/src/rpc_methods/staking/staking_rpc_namespace.dart packages/komodo_defi_sdk/lib/src/staking/staking_manager.dart packages/komodo_defi_sdk/example/lib/screens/staking_page.dart`
- `flutter analyze` *(fails: multiple existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_6877e85065e08326842dadd8374e6dfe