### PR TITLE
feat(migration): add MigrationPreview type and freezed generated files

### DIFF
--- a/packages/komodo_defi_types/lib/src/migration/migration_preview.dart
+++ b/packages/komodo_defi_types/lib/src/migration/migration_preview.dart
@@ -1,7 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart'
-    show WithdrawResult, WalletId, WithdrawalPreview;
+    show WalletId, WithdrawalPreview;
 
 part 'migration_preview.freezed.dart';
 part 'migration_preview.g.dart';

--- a/packages/komodo_defi_types/lib/src/migration/migration_preview.dart
+++ b/packages/komodo_defi_types/lib/src/migration/migration_preview.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart'
+    show WithdrawResult, WalletId, WithdrawalPreview;
+
+part 'migration_preview.freezed.dart';
+part 'migration_preview.g.dart';
+
+@freezed
+abstract class MigrationPreview with _$MigrationPreview {
+  @JsonSerializable(fieldRename: FieldRename.snake)
+  const factory MigrationPreview({
+    required WalletId fromWalletId,
+    required WalletId toWalletId,
+    required String pubkeyHash,
+    required List<WithdrawalPreview> withdrawals,
+  }) = _MigrationPreview;
+
+  factory MigrationPreview.fromJson(JsonMap json) =>
+      _$MigrationPreviewFromJson(json);
+}

--- a/packages/komodo_defi_types/lib/src/migration/migration_preview.dart
+++ b/packages/komodo_defi_types/lib/src/migration/migration_preview.dart
@@ -8,7 +8,7 @@ part 'migration_preview.g.dart';
 
 @freezed
 abstract class MigrationPreview with _$MigrationPreview {
-  @JsonSerializable(fieldRename: FieldRename.snake)
+  @JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
   const factory MigrationPreview({
     required WalletId fromWalletId,
     required WalletId toWalletId,

--- a/packages/komodo_defi_types/lib/src/migration/migration_preview.freezed.dart
+++ b/packages/komodo_defi_types/lib/src/migration/migration_preview.freezed.dart
@@ -276,7 +276,7 @@ extension MigrationPreviewPatterns on MigrationPreview {
 
 /// @nodoc
 
-@JsonSerializable(fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
 class _MigrationPreview implements MigrationPreview {
   const _MigrationPreview(
       {required this.fromWalletId,

--- a/packages/komodo_defi_types/lib/src/migration/migration_preview.freezed.dart
+++ b/packages/komodo_defi_types/lib/src/migration/migration_preview.freezed.dart
@@ -1,0 +1,399 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'migration_preview.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$MigrationPreview {
+  WalletId get fromWalletId;
+  WalletId get toWalletId;
+  String get pubkeyHash;
+  List<WithdrawalPreview> get withdrawals;
+
+  /// Create a copy of MigrationPreview
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $MigrationPreviewCopyWith<MigrationPreview> get copyWith =>
+      _$MigrationPreviewCopyWithImpl<MigrationPreview>(
+          this as MigrationPreview, _$identity);
+
+  /// Serializes this MigrationPreview to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is MigrationPreview &&
+            (identical(other.fromWalletId, fromWalletId) ||
+                other.fromWalletId == fromWalletId) &&
+            (identical(other.toWalletId, toWalletId) ||
+                other.toWalletId == toWalletId) &&
+            (identical(other.pubkeyHash, pubkeyHash) ||
+                other.pubkeyHash == pubkeyHash) &&
+            const DeepCollectionEquality()
+                .equals(other.withdrawals, withdrawals));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, fromWalletId, toWalletId,
+      pubkeyHash, const DeepCollectionEquality().hash(withdrawals));
+
+  @override
+  String toString() {
+    return 'MigrationPreview(fromWalletId: $fromWalletId, toWalletId: $toWalletId, pubkeyHash: $pubkeyHash, withdrawals: $withdrawals)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $MigrationPreviewCopyWith<$Res> {
+  factory $MigrationPreviewCopyWith(
+          MigrationPreview value, $Res Function(MigrationPreview) _then) =
+      _$MigrationPreviewCopyWithImpl;
+  @useResult
+  $Res call(
+      {WalletId fromWalletId,
+      WalletId toWalletId,
+      String pubkeyHash,
+      List<WithdrawalPreview> withdrawals});
+}
+
+/// @nodoc
+class _$MigrationPreviewCopyWithImpl<$Res>
+    implements $MigrationPreviewCopyWith<$Res> {
+  _$MigrationPreviewCopyWithImpl(this._self, this._then);
+
+  final MigrationPreview _self;
+  final $Res Function(MigrationPreview) _then;
+
+  /// Create a copy of MigrationPreview
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? fromWalletId = null,
+    Object? toWalletId = null,
+    Object? pubkeyHash = null,
+    Object? withdrawals = null,
+  }) {
+    return _then(_self.copyWith(
+      fromWalletId: null == fromWalletId
+          ? _self.fromWalletId
+          : fromWalletId // ignore: cast_nullable_to_non_nullable
+              as WalletId,
+      toWalletId: null == toWalletId
+          ? _self.toWalletId
+          : toWalletId // ignore: cast_nullable_to_non_nullable
+              as WalletId,
+      pubkeyHash: null == pubkeyHash
+          ? _self.pubkeyHash
+          : pubkeyHash // ignore: cast_nullable_to_non_nullable
+              as String,
+      withdrawals: null == withdrawals
+          ? _self.withdrawals
+          : withdrawals // ignore: cast_nullable_to_non_nullable
+              as List<WithdrawalPreview>,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [MigrationPreview].
+extension MigrationPreviewPatterns on MigrationPreview {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_MigrationPreview value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _MigrationPreview() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_MigrationPreview value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MigrationPreview():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_MigrationPreview value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MigrationPreview() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(WalletId fromWalletId, WalletId toWalletId,
+            String pubkeyHash, List<WithdrawalPreview> withdrawals)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _MigrationPreview() when $default != null:
+        return $default(_that.fromWalletId, _that.toWalletId, _that.pubkeyHash,
+            _that.withdrawals);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(WalletId fromWalletId, WalletId toWalletId,
+            String pubkeyHash, List<WithdrawalPreview> withdrawals)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MigrationPreview():
+        return $default(_that.fromWalletId, _that.toWalletId, _that.pubkeyHash,
+            _that.withdrawals);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(WalletId fromWalletId, WalletId toWalletId,
+            String pubkeyHash, List<WithdrawalPreview> withdrawals)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MigrationPreview() when $default != null:
+        return $default(_that.fromWalletId, _that.toWalletId, _that.pubkeyHash,
+            _that.withdrawals);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class _MigrationPreview implements MigrationPreview {
+  const _MigrationPreview(
+      {required this.fromWalletId,
+      required this.toWalletId,
+      required this.pubkeyHash,
+      required final List<WithdrawalPreview> withdrawals})
+      : _withdrawals = withdrawals;
+  factory _MigrationPreview.fromJson(Map<String, dynamic> json) =>
+      _$MigrationPreviewFromJson(json);
+
+  @override
+  final WalletId fromWalletId;
+  @override
+  final WalletId toWalletId;
+  @override
+  final String pubkeyHash;
+  final List<WithdrawalPreview> _withdrawals;
+  @override
+  List<WithdrawalPreview> get withdrawals {
+    if (_withdrawals is EqualUnmodifiableListView) return _withdrawals;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_withdrawals);
+  }
+
+  /// Create a copy of MigrationPreview
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$MigrationPreviewCopyWith<_MigrationPreview> get copyWith =>
+      __$MigrationPreviewCopyWithImpl<_MigrationPreview>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$MigrationPreviewToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _MigrationPreview &&
+            (identical(other.fromWalletId, fromWalletId) ||
+                other.fromWalletId == fromWalletId) &&
+            (identical(other.toWalletId, toWalletId) ||
+                other.toWalletId == toWalletId) &&
+            (identical(other.pubkeyHash, pubkeyHash) ||
+                other.pubkeyHash == pubkeyHash) &&
+            const DeepCollectionEquality()
+                .equals(other._withdrawals, _withdrawals));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, fromWalletId, toWalletId,
+      pubkeyHash, const DeepCollectionEquality().hash(_withdrawals));
+
+  @override
+  String toString() {
+    return 'MigrationPreview(fromWalletId: $fromWalletId, toWalletId: $toWalletId, pubkeyHash: $pubkeyHash, withdrawals: $withdrawals)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$MigrationPreviewCopyWith<$Res>
+    implements $MigrationPreviewCopyWith<$Res> {
+  factory _$MigrationPreviewCopyWith(
+          _MigrationPreview value, $Res Function(_MigrationPreview) _then) =
+      __$MigrationPreviewCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {WalletId fromWalletId,
+      WalletId toWalletId,
+      String pubkeyHash,
+      List<WithdrawalPreview> withdrawals});
+}
+
+/// @nodoc
+class __$MigrationPreviewCopyWithImpl<$Res>
+    implements _$MigrationPreviewCopyWith<$Res> {
+  __$MigrationPreviewCopyWithImpl(this._self, this._then);
+
+  final _MigrationPreview _self;
+  final $Res Function(_MigrationPreview) _then;
+
+  /// Create a copy of MigrationPreview
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? fromWalletId = null,
+    Object? toWalletId = null,
+    Object? pubkeyHash = null,
+    Object? withdrawals = null,
+  }) {
+    return _then(_MigrationPreview(
+      fromWalletId: null == fromWalletId
+          ? _self.fromWalletId
+          : fromWalletId // ignore: cast_nullable_to_non_nullable
+              as WalletId,
+      toWalletId: null == toWalletId
+          ? _self.toWalletId
+          : toWalletId // ignore: cast_nullable_to_non_nullable
+              as WalletId,
+      pubkeyHash: null == pubkeyHash
+          ? _self.pubkeyHash
+          : pubkeyHash // ignore: cast_nullable_to_non_nullable
+              as String,
+      withdrawals: null == withdrawals
+          ? _self._withdrawals
+          : withdrawals // ignore: cast_nullable_to_non_nullable
+              as List<WithdrawalPreview>,
+    ));
+  }
+}
+
+// dart format on

--- a/packages/komodo_defi_types/lib/src/migration/migration_preview.g.dart
+++ b/packages/komodo_defi_types/lib/src/migration/migration_preview.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'migration_preview.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_MigrationPreview _$MigrationPreviewFromJson(Map<String, dynamic> json) =>
+    _MigrationPreview(
+      fromWalletId:
+          WalletId.fromJson(json['from_wallet_id'] as Map<String, dynamic>),
+      toWalletId:
+          WalletId.fromJson(json['to_wallet_id'] as Map<String, dynamic>),
+      pubkeyHash: json['pubkey_hash'] as String,
+      withdrawals: (json['withdrawals'] as List<dynamic>)
+          .map((e) => WithdrawResult.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$MigrationPreviewToJson(_MigrationPreview instance) =>
+    <String, dynamic>{
+      'from_wallet_id': instance.fromWalletId,
+      'to_wallet_id': instance.toWalletId,
+      'pubkey_hash': instance.pubkeyHash,
+      'withdrawals': instance.withdrawals,
+    };

--- a/packages/komodo_defi_types/lib/src/migration/migration_preview.g.dart
+++ b/packages/komodo_defi_types/lib/src/migration/migration_preview.g.dart
@@ -14,7 +14,7 @@ _MigrationPreview _$MigrationPreviewFromJson(Map<String, dynamic> json) =>
           WalletId.fromJson(json['to_wallet_id'] as Map<String, dynamic>),
       pubkeyHash: json['pubkey_hash'] as String,
       withdrawals: (json['withdrawals'] as List<dynamic>)
-          .map((e) => WithdrawResult.fromJson(e as Map<String, dynamic>))
+          .map((e) => WithdrawalPreview.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 

--- a/packages/komodo_defi_types/lib/src/migration/migration_preview.g.dart
+++ b/packages/komodo_defi_types/lib/src/migration/migration_preview.g.dart
@@ -20,8 +20,8 @@ _MigrationPreview _$MigrationPreviewFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$MigrationPreviewToJson(_MigrationPreview instance) =>
     <String, dynamic>{
-      'from_wallet_id': instance.fromWalletId,
-      'to_wallet_id': instance.toWalletId,
+      'from_wallet_id': instance.fromWalletId.toJson(),
+      'to_wallet_id': instance.toWalletId.toJson(),
       'pubkey_hash': instance.pubkeyHash,
-      'withdrawals': instance.withdrawals,
+      'withdrawals': instance.withdrawals.map((e) => e.toJson()).toList(),
     };

--- a/packages/komodo_defi_types/lib/src/public_key/confirm_address_details.freezed.dart
+++ b/packages/komodo_defi_types/lib/src/public_key/confirm_address_details.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -78,6 +77,167 @@ class _$ConfirmAddressDetailsCopyWithImpl<$Res>
           : expectedAddress // ignore: cast_nullable_to_non_nullable
               as String,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ConfirmAddressDetails].
+extension ConfirmAddressDetailsPatterns on ConfirmAddressDetails {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ConfirmAddressDetails value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ConfirmAddressDetails() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ConfirmAddressDetails value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ConfirmAddressDetails():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ConfirmAddressDetails value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ConfirmAddressDetails() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(@JsonKey(name: 'expected_address') String expectedAddress)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ConfirmAddressDetails() when $default != null:
+        return $default(_that.expectedAddress);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(@JsonKey(name: 'expected_address') String expectedAddress)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ConfirmAddressDetails():
+        return $default(_that.expectedAddress);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @JsonKey(name: 'expected_address') String expectedAddress)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ConfirmAddressDetails() when $default != null:
+        return $default(_that.expectedAddress);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/komodo_defi_types/lib/src/public_key/new_address_state.freezed.dart
+++ b/packages/komodo_defi_types/lib/src/public_key/new_address_state.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -119,6 +118,172 @@ class _$NewAddressStateCopyWithImpl<$Res>
           : error // ignore: cast_nullable_to_non_nullable
               as String?,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [NewAddressState].
+extension NewAddressStatePatterns on NewAddressState {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_NewAddressState value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _NewAddressState() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_NewAddressState value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _NewAddressState():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_NewAddressState value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _NewAddressState() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(NewAddressStatus status, String? message, int? taskId,
+            NewAddressInfo? address, String? expectedAddress, String? error)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _NewAddressState() when $default != null:
+        return $default(_that.status, _that.message, _that.taskId,
+            _that.address, _that.expectedAddress, _that.error);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(NewAddressStatus status, String? message, int? taskId,
+            NewAddressInfo? address, String? expectedAddress, String? error)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _NewAddressState():
+        return $default(_that.status, _that.message, _that.taskId,
+            _that.address, _that.expectedAddress, _that.error);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(NewAddressStatus status, String? message, int? taskId,
+            NewAddressInfo? address, String? expectedAddress, String? error)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _NewAddressState() when $default != null:
+        return $default(_that.status, _that.message, _that.taskId,
+            _that.address, _that.expectedAddress, _that.error);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/komodo_defi_types/lib/src/transactions/fee_info.freezed.dart
+++ b/packages/komodo_defi_types/lib/src/transactions/fee_info.freezed.dart
@@ -1,6 +1,5 @@
-// dart format width=80
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -70,6 +69,266 @@ class _$FeeInfoCopyWithImpl<$Res> implements $FeeInfoCopyWith<$Res> {
           : coin // ignore: cast_nullable_to_non_nullable
               as String,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [FeeInfo].
+extension FeeInfoPatterns on FeeInfo {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(FeeInfoUtxoFixed value)? utxoFixed,
+    TResult Function(FeeInfoUtxoPerKbyte value)? utxoPerKbyte,
+    TResult Function(FeeInfoEthGas value)? ethGas,
+    TResult Function(FeeInfoQrc20Gas value)? qrc20Gas,
+    TResult Function(FeeInfoCosmosGas value)? cosmosGas,
+    TResult Function(FeeInfoTendermint value)? tendermint,
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case FeeInfoUtxoFixed() when utxoFixed != null:
+        return utxoFixed(_that);
+      case FeeInfoUtxoPerKbyte() when utxoPerKbyte != null:
+        return utxoPerKbyte(_that);
+      case FeeInfoEthGas() when ethGas != null:
+        return ethGas(_that);
+      case FeeInfoQrc20Gas() when qrc20Gas != null:
+        return qrc20Gas(_that);
+      case FeeInfoCosmosGas() when cosmosGas != null:
+        return cosmosGas(_that);
+      case FeeInfoTendermint() when tendermint != null:
+        return tendermint(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(FeeInfoUtxoFixed value) utxoFixed,
+    required TResult Function(FeeInfoUtxoPerKbyte value) utxoPerKbyte,
+    required TResult Function(FeeInfoEthGas value) ethGas,
+    required TResult Function(FeeInfoQrc20Gas value) qrc20Gas,
+    required TResult Function(FeeInfoCosmosGas value) cosmosGas,
+    required TResult Function(FeeInfoTendermint value) tendermint,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case FeeInfoUtxoFixed():
+        return utxoFixed(_that);
+      case FeeInfoUtxoPerKbyte():
+        return utxoPerKbyte(_that);
+      case FeeInfoEthGas():
+        return ethGas(_that);
+      case FeeInfoQrc20Gas():
+        return qrc20Gas(_that);
+      case FeeInfoCosmosGas():
+        return cosmosGas(_that);
+      case FeeInfoTendermint():
+        return tendermint(_that);
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(FeeInfoUtxoFixed value)? utxoFixed,
+    TResult? Function(FeeInfoUtxoPerKbyte value)? utxoPerKbyte,
+    TResult? Function(FeeInfoEthGas value)? ethGas,
+    TResult? Function(FeeInfoQrc20Gas value)? qrc20Gas,
+    TResult? Function(FeeInfoCosmosGas value)? cosmosGas,
+    TResult? Function(FeeInfoTendermint value)? tendermint,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case FeeInfoUtxoFixed() when utxoFixed != null:
+        return utxoFixed(_that);
+      case FeeInfoUtxoPerKbyte() when utxoPerKbyte != null:
+        return utxoPerKbyte(_that);
+      case FeeInfoEthGas() when ethGas != null:
+        return ethGas(_that);
+      case FeeInfoQrc20Gas() when qrc20Gas != null:
+        return qrc20Gas(_that);
+      case FeeInfoCosmosGas() when cosmosGas != null:
+        return cosmosGas(_that);
+      case FeeInfoTendermint() when tendermint != null:
+        return tendermint(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String coin, Decimal amount)? utxoFixed,
+    TResult Function(String coin, Decimal amount)? utxoPerKbyte,
+    TResult Function(
+            String coin, Decimal gasPrice, int gas, Decimal? totalGasFee)?
+        ethGas,
+    TResult Function(
+            String coin, Decimal gasPrice, int gasLimit, Decimal? totalGasFee)?
+        qrc20Gas,
+    TResult Function(String coin, Decimal gasPrice, int gasLimit)? cosmosGas,
+    TResult Function(String coin, Decimal amount, int gasLimit)? tendermint,
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case FeeInfoUtxoFixed() when utxoFixed != null:
+        return utxoFixed(_that.coin, _that.amount);
+      case FeeInfoUtxoPerKbyte() when utxoPerKbyte != null:
+        return utxoPerKbyte(_that.coin, _that.amount);
+      case FeeInfoEthGas() when ethGas != null:
+        return ethGas(_that.coin, _that.gasPrice, _that.gas, _that.totalGasFee);
+      case FeeInfoQrc20Gas() when qrc20Gas != null:
+        return qrc20Gas(
+            _that.coin, _that.gasPrice, _that.gasLimit, _that.totalGasFee);
+      case FeeInfoCosmosGas() when cosmosGas != null:
+        return cosmosGas(_that.coin, _that.gasPrice, _that.gasLimit);
+      case FeeInfoTendermint() when tendermint != null:
+        return tendermint(_that.coin, _that.amount, _that.gasLimit);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String coin, Decimal amount) utxoFixed,
+    required TResult Function(String coin, Decimal amount) utxoPerKbyte,
+    required TResult Function(
+            String coin, Decimal gasPrice, int gas, Decimal? totalGasFee)
+        ethGas,
+    required TResult Function(
+            String coin, Decimal gasPrice, int gasLimit, Decimal? totalGasFee)
+        qrc20Gas,
+    required TResult Function(String coin, Decimal gasPrice, int gasLimit)
+        cosmosGas,
+    required TResult Function(String coin, Decimal amount, int gasLimit)
+        tendermint,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case FeeInfoUtxoFixed():
+        return utxoFixed(_that.coin, _that.amount);
+      case FeeInfoUtxoPerKbyte():
+        return utxoPerKbyte(_that.coin, _that.amount);
+      case FeeInfoEthGas():
+        return ethGas(_that.coin, _that.gasPrice, _that.gas, _that.totalGasFee);
+      case FeeInfoQrc20Gas():
+        return qrc20Gas(
+            _that.coin, _that.gasPrice, _that.gasLimit, _that.totalGasFee);
+      case FeeInfoCosmosGas():
+        return cosmosGas(_that.coin, _that.gasPrice, _that.gasLimit);
+      case FeeInfoTendermint():
+        return tendermint(_that.coin, _that.amount, _that.gasLimit);
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String coin, Decimal amount)? utxoFixed,
+    TResult? Function(String coin, Decimal amount)? utxoPerKbyte,
+    TResult? Function(
+            String coin, Decimal gasPrice, int gas, Decimal? totalGasFee)?
+        ethGas,
+    TResult? Function(
+            String coin, Decimal gasPrice, int gasLimit, Decimal? totalGasFee)?
+        qrc20Gas,
+    TResult? Function(String coin, Decimal gasPrice, int gasLimit)? cosmosGas,
+    TResult? Function(String coin, Decimal amount, int gasLimit)? tendermint,
+  }) {
+    final _that = this;
+    switch (_that) {
+      case FeeInfoUtxoFixed() when utxoFixed != null:
+        return utxoFixed(_that.coin, _that.amount);
+      case FeeInfoUtxoPerKbyte() when utxoPerKbyte != null:
+        return utxoPerKbyte(_that.coin, _that.amount);
+      case FeeInfoEthGas() when ethGas != null:
+        return ethGas(_that.coin, _that.gasPrice, _that.gas, _that.totalGasFee);
+      case FeeInfoQrc20Gas() when qrc20Gas != null:
+        return qrc20Gas(
+            _that.coin, _that.gasPrice, _that.gasLimit, _that.totalGasFee);
+      case FeeInfoCosmosGas() when cosmosGas != null:
+        return cosmosGas(_that.coin, _that.gasPrice, _that.gasLimit);
+      case FeeInfoTendermint() when tendermint != null:
+        return tendermint(_that.coin, _that.amount, _that.gasLimit);
+      case _:
+        return null;
+    }
   }
 }
 

--- a/packages/komodo_defi_types/lib/src/types.dart
+++ b/packages/komodo_defi_types/lib/src/types.dart
@@ -27,6 +27,7 @@ export 'generic/result.dart';
 export 'generic/sync_status.dart';
 export 'komodo_defi_types_base.dart';
 export 'legacy/legacy_coin_model.dart';
+export 'migration/migration_preview.dart';
 export 'protocols/base/exceptions.dart';
 export 'protocols/base/explorer_url_pattern.dart';
 export 'protocols/base/protocol_class.dart';

--- a/packages/komodo_defi_types/lib/src/withdrawal/withdrawal_types.dart
+++ b/packages/komodo_defi_types/lib/src/withdrawal/withdrawal_types.dart
@@ -197,7 +197,41 @@ class WithdrawParameters extends Equatable {
 }
 
 /// Preview of a withdrawal operation, using same structure as API response
-typedef WithdrawalPreview = WithdrawResult;
+class WithdrawalPreview extends WithdrawResult {
+  WithdrawalPreview({
+    required super.txHex,
+    required super.txHash,
+    required super.from,
+    required super.to,
+    required super.balanceChanges,
+    required super.blockHeight,
+    required super.timestamp,
+    required super.fee,
+    required super.coin,
+    super.internalId,
+    super.kmdRewards,
+    super.memo,
+  });
+
+  factory WithdrawalPreview.fromWithdrawResult(WithdrawResult result) =>
+      WithdrawalPreview(
+        txHex: result.txHex,
+        txHash: result.txHash,
+        from: result.from,
+        to: result.to,
+        balanceChanges: result.balanceChanges,
+        blockHeight: result.blockHeight,
+        timestamp: result.timestamp,
+        fee: result.fee,
+        coin: result.coin,
+        internalId: result.internalId,
+        kmdRewards: result.kmdRewards,
+        memo: result.memo,
+      );
+
+  factory WithdrawalPreview.fromJson(JsonMap json) =>
+      WithdrawalPreview.fromWithdrawResult(WithdrawResult.fromJson(json));
+}
 
 enum Bip44Chain {
   external._('External', 'External', 0),


### PR DESCRIPTION
## Summary
- add `MigrationPreview` data class to represent batches of withdrawals between wallets
- re-generate freezed and index files for `komodo_defi_types`

## Testing
- `dart format packages/komodo_defi_types/lib/src/migration/migration_preview.dart`
- `flutter analyze packages/komodo_defi_types`
- `flutter build web` *(fails as expected)*
- `flutter build web` *(fails again)*

------
https://chatgpt.com/codex/tasks/task_e_687a07cc40e8833187126da247e2331b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new migration preview data type for enhanced migration-related operations.
  * Added pattern-matching methods to address details, new address state, and fee information types for more flexible and expressive handling.

* **Documentation**
  * Updated exports to include the new migration preview type, making it accessible for use in other modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->