### PR TITLE
feat(wallet_build_transformer): add flexible CDN configuration

### DIFF
--- a/packages/komodo_wallet_build_transformer/lib/src/steps/fetch_coin_assets_build_step.dart
+++ b/packages/komodo_wallet_build_transformer/lib/src/steps/fetch_coin_assets_build_step.dart
@@ -38,13 +38,8 @@ class FetchCoinAssetsBuildStep extends BuildStep {
     String? githubToken,
   }) {
     final config = buildConfig.coinCIConfig.copyWith(
-      // If the branch is `master`, use the repository mirror URL to avoid
-      // rate limiting issues. Consider refactoring config to allow branch
-      // specific mirror URLs to remove this workaround.
-      coinsRepoContentUrl:
-          buildConfig.coinCIConfig.isMainBranch
-              ? buildConfig.coinCIConfig.coinsRepoContentUrl
-              : buildConfig.coinCIConfig.rawContentUrl,
+      // Use the effective content URL which checks CDN mirrors
+      coinsRepoContentUrl: buildConfig.coinCIConfig.effectiveContentUrl,
     );
 
     final provider = GithubApiProvider.withBaseUrl(

--- a/packages/komodo_wallet_build_transformer/lib/src/steps/models/github/github_file.dart
+++ b/packages/komodo_wallet_build_transformer/lib/src/steps/models/github/github_file.dart
@@ -18,33 +18,34 @@ class GitHubFile {
 
   /// Creates a new instance of [GitHubFile] from a JSON map.
   factory GitHubFile.fromJson(Map<String, dynamic> data) => GitHubFile(
-        name: data['name'] as String,
-        path: data['path'] as String,
-        sha: data['sha'] as String,
-        size: data['size'] as int,
-        url: data['url'] as String?,
-        htmlUrl: data['html_url'] as String?,
-        gitUrl: data['git_url'] as String?,
-        downloadUrl: data['download_url'] as String,
-        type: data['type'] as String,
-        links: data['_links'] == null
+    name: data['name'] as String,
+    path: data['path'] as String,
+    sha: data['sha'] as String,
+    size: data['size'] as int,
+    url: data['url'] as String?,
+    htmlUrl: data['html_url'] as String?,
+    gitUrl: data['git_url'] as String?,
+    downloadUrl: data['download_url'] as String,
+    type: data['type'] as String,
+    links:
+        data['_links'] == null
             ? null
             : Links.fromJson(data['_links'] as Map<String, dynamic>),
-      );
+  );
 
   /// Converts the [GitHubFile] instance to a JSON map.
   Map<String, dynamic> toJson() => <String, dynamic>{
-        'name': name,
-        'path': path,
-        'sha': sha,
-        'size': size,
-        'url': url,
-        'html_url': htmlUrl,
-        'git_url': gitUrl,
-        'download_url': downloadUrl,
-        'type': type,
-        '_links': links?.toJson(),
-      };
+    'name': name,
+    'path': path,
+    'sha': sha,
+    'size': size,
+    'url': url,
+    'html_url': htmlUrl,
+    'git_url': gitUrl,
+    'download_url': downloadUrl,
+    'type': type,
+    '_links': links?.toJson(),
+  };
 
   /// The name of the file.
   final String name;
@@ -103,15 +104,15 @@ class GitHubFile {
     );
   }
 
-  GitHubFile withStaticHostingUrl(String branch) {
-    final staticHostingUrls = {
-      'master': 'https://komodoplatform.github.io/coins',
-    };
+  GitHubFile withStaticHostingUrl(
+    String branch,
+    Map<String, String> cdnMirrors,
+  ) {
+    // Check if a CDN mirror is configured for this branch
+    final cdnUrl = cdnMirrors[branch];
 
     return copyWith(
-      downloadUrl: staticHostingUrls.containsKey(branch)
-          ? '${staticHostingUrls[branch]}/$path'
-          : downloadUrl,
+      downloadUrl: cdnUrl != null ? '$cdnUrl/$path' : downloadUrl,
     );
   }
 }


### PR DESCRIPTION
## Summary
- add `cdnBranchMirrors` property to `CoinBuildConfig`
- update asset fetch step to use `effectiveContentUrl`
- allow `GitHubFile.withStaticHostingUrl` to accept custom CDN mirror maps

## Testing
- `dart format packages/komodo_wallet_build_transformer/lib/src/steps/models/coin_assets/coin_build_config.dart packages/komodo_wallet_build_transformer/lib/src/steps/fetch_coin_assets_build_step.dart packages/komodo_wallet_build_transformer/lib/src/steps/models/github/github_file.dart`
- `flutter analyze` *(fails: 2466 issues)*

------
https://chatgpt.com/codex/tasks/task_e_687bf85cdc60832697bef22a5d964e5a