### PR TITLE
feat(example): show market data in example asset list

### DIFF
--- a/packages/komodo_defi_sdk/example/lib/blocs/asset_market_info/asset_market_info_cubit.dart
+++ b/packages/komodo_defi_sdk/example/lib/blocs/asset_market_info/asset_market_info_cubit.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:decimal/decimal.dart';
+import 'package:equatable/equatable.dart';
+import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+part 'asset_market_info_state.dart';
+
+class AssetMarketInfoCubit extends Cubit<AssetMarketInfoState> {
+  AssetMarketInfoCubit({required KomodoDefiSdk sdk, required Asset asset})
+    : _sdk = sdk,
+      _asset = asset,
+      super(const AssetMarketInfoState()) {
+    _init();
+  }
+
+  final KomodoDefiSdk _sdk;
+  final Asset _asset;
+
+  StreamSubscription<BalanceInfo>? _balanceSub;
+
+  Future<void> _init() async {
+    final price = await _sdk.marketData.maybeFiatPrice(
+      _asset.id,
+      fiatCurrency: 'usd',
+    );
+    final change = await _sdk.marketData.priceChange24h(
+      _asset.id,
+      fiatCurrency: 'usd',
+    );
+
+    emit(state.copyWith(price: price, change24h: change));
+
+    _balanceSub = _sdk.balances
+        .watchBalance(_asset.id, activateIfNeeded: false)
+        .listen((balance) {
+          final usdBalance = price != null ? price * balance.total : null;
+          emit(state.copyWith(usdBalance: usdBalance));
+        });
+  }
+
+  @override
+  Future<void> close() {
+    _balanceSub?.cancel();
+    return super.close();
+  }
+}

--- a/packages/komodo_defi_sdk/example/lib/blocs/asset_market_info/asset_market_info_state.dart
+++ b/packages/komodo_defi_sdk/example/lib/blocs/asset_market_info/asset_market_info_state.dart
@@ -1,0 +1,24 @@
+part of 'asset_market_info_cubit.dart';
+
+class AssetMarketInfoState extends Equatable {
+  const AssetMarketInfoState({this.usdBalance, this.price, this.change24h});
+
+  final Decimal? usdBalance;
+  final Decimal? price;
+  final Decimal? change24h;
+
+  AssetMarketInfoState copyWith({
+    Decimal? usdBalance,
+    Decimal? price,
+    Decimal? change24h,
+  }) {
+    return AssetMarketInfoState(
+      usdBalance: usdBalance ?? this.usdBalance,
+      price: price ?? this.price,
+      change24h: change24h ?? this.change24h,
+    );
+  }
+
+  @override
+  List<Object?> get props => [usdBalance, price, change24h];
+}

--- a/packages/komodo_defi_sdk/example/lib/blocs/blocs.dart
+++ b/packages/komodo_defi_sdk/example/lib/blocs/blocs.dart
@@ -1,1 +1,2 @@
 export 'auth/auth_bloc.dart';
+export 'asset_market_info/asset_market_info_cubit.dart';

--- a/packages/komodo_defi_sdk/example/lib/widgets/assets/asset_item.dart
+++ b/packages/komodo_defi_sdk/example/lib/widgets/assets/asset_item.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:komodo_ui/komodo_ui.dart';
+import 'asset_market_info.dart';
 
 class AssetItemWidget extends StatelessWidget {
   const AssetItemWidget({
@@ -96,6 +97,8 @@ class _AssetItemTrailing extends StatelessWidget {
             activateIfNeeded: false,
           ),
         ),
+        const SizedBox(width: 8),
+        AssetMarketInfo(asset: asset),
         const SizedBox(width: 8),
         const Icon(Icons.arrow_forward_ios),
       ],

--- a/packages/komodo_defi_sdk/example/lib/widgets/assets/asset_market_info.dart
+++ b/packages/komodo_defi_sdk/example/lib/widgets/assets/asset_market_info.dart
@@ -1,0 +1,76 @@
+import 'package:decimal/decimal.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+
+import '../../blocs/asset_market_info/asset_market_info_cubit.dart';
+
+class AssetMarketInfo extends StatelessWidget {
+  const AssetMarketInfo({super.key, required this.asset});
+
+  final Asset asset;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create:
+          (_) => AssetMarketInfoCubit(
+            sdk: context.read<KomodoDefiSdk>(),
+            asset: asset,
+          ),
+      child: const _AssetMarketInfoView(),
+    );
+  }
+}
+
+class _AssetMarketInfoView extends StatelessWidget {
+  const _AssetMarketInfoView();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AssetMarketInfoCubit, AssetMarketInfoState>(
+      builder: (context, state) {
+        final balanceStr = _formatCurrency(state.usdBalance);
+        final priceStr = _formatCurrency(state.price);
+        final changeStr = _formatChange(state.change24h);
+        final color =
+            state.change24h == null
+                ? null
+                : state.change24h! >= Decimal.zero
+                ? Colors.green
+                : Colors.red;
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(balanceStr, style: Theme.of(context).textTheme.bodySmall),
+            Text(priceStr, style: Theme.of(context).textTheme.bodySmall),
+            Text(
+              changeStr,
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: color),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+String _formatCurrency(Decimal? value) {
+  if (value == null) return '--';
+  final number = double.parse(value.toString());
+  final format = NumberFormat.currency(symbol: r'$');
+  return format.format(number);
+}
+
+String _formatChange(Decimal? value) {
+  if (value == null) return '--';
+  final percent = double.parse((value * Decimal.fromInt(100)).toString());
+  final format = NumberFormat('+#,##0.00%;-#,##0.00%');
+  return format.format(percent / 100);
+}


### PR DESCRIPTION
## Summary
- display market data in each asset row
- use `AssetMarketInfoCubit` to fetch price and 24h change
- move market info widget to its own file

## Testing
- `dart format packages/komodo_defi_sdk/example/lib/widgets/assets/asset_item.dart packages/komodo_defi_sdk/example/lib/widgets/assets/asset_market_info.dart packages/komodo_defi_sdk/example/lib/blocs/asset_market_info/asset_market_info_cubit.dart packages/komodo_defi_sdk/example/lib/blocs/asset_market_info/asset_market_info_state.dart packages/komodo_defi_sdk/example/lib/blocs/blocs.dart`
- `flutter analyze lib` *(in `packages/komodo_defi_sdk/example`)*
- `flutter build web --dry-run` *(fails as expected)*
- `flutter build web` (runs successfully)

------
https://chatgpt.com/codex/tasks/task_e_687c232042ec83318a6bc0ddada06b08