### PR TITLE
feat(rpc): support max_connected on activation

### DIFF
--- a/packages/komodo_defi_rpc_methods/lib/src/common_structures/activation/activation_params/activation_params.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/common_structures/activation/activation_params/activation_params.dart
@@ -377,7 +377,13 @@ enum ScanPolicy {
 /// Contains information about electrum & lightwallet_d servers for coins being used
 /// in 'Electrum' or 'Light' mode
 class ActivationRpcData {
-  ActivationRpcData({this.lightWalletDServers, this.electrum, this.syncParams});
+  ActivationRpcData({
+    this.lightWalletDServers,
+    this.electrum,
+    this.syncParams,
+    this.minConnected,
+    this.maxConnected,
+  });
 
   /// Creates [ActivationRpcData] from JSON configuration
   factory ActivationRpcData.fromJson(JsonMap json) {
@@ -392,6 +398,8 @@ class ActivationRpcData {
               ?.map((e) => ActivationServers.fromJsonConfig(e as JsonMap))
               .toList(),
       syncParams: json.valueOrNull<dynamic>('sync_params'),
+      minConnected: json.valueOrNull<int>('min_connected'),
+      maxConnected: json.valueOrNull<int>('max_connected'),
     );
   }
 
@@ -409,6 +417,12 @@ class ActivationRpcData {
   /// - date (a unix timestamp)
   final dynamic syncParams;
 
+  /// Optional. Minimum required electrum connections.
+  final int? minConnected;
+
+  /// Optional. Maximum electrum connections to establish.
+  final int? maxConnected;
+
   bool get isEmpty => [lightWalletDServers, electrum, syncParams].every(
     (element) =>
         element == null &&
@@ -423,6 +437,8 @@ class ActivationRpcData {
       'servers': electrum!.map((e) => e.toJsonRequest()).toList(),
     },
     if (syncParams != null) 'sync_params': syncParams,
+    if (minConnected != null) 'min_connected': minConnected,
+    if (maxConnected != null) 'max_connected': maxConnected,
   };
 }
 

--- a/packages/komodo_defi_rpc_methods/lib/src/common_structures/activation/activation_params/activation_params.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/common_structures/activation/activation_params/activation_params.dart
@@ -382,7 +382,7 @@ class ActivationRpcData {
     this.electrum,
     this.syncParams,
     this.minConnected,
-    this.maxConnected,
+    this.maxConnected = 1,
   });
 
   /// Creates [ActivationRpcData] from JSON configuration


### PR DESCRIPTION
## Summary
- add min_connected and max_connected handling in `ActivationRpcData`

## Testing
- `flutter analyze`
- `dart test packages/komodo_coins/test/komodo_coins_test.dart` *(fails: Could not find package `test`)*

------
https://chatgpt.com/codex/tasks/task_e_687e021e100483269607cfab2ed30412