### PR TITLE
feat(zhtlc): complete rpc integration

### DIFF
--- a/packages/komodo_defi_rpc_methods/lib/src/common_structures/activation/activation_params/activation_params.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/common_structures/activation/activation_params/activation_params.dart
@@ -420,7 +420,7 @@ class ActivationRpcData {
     if (lightWalletDServers != null)
       'light_wallet_d_servers': lightWalletDServers,
     if (electrum != null) ...{
-      'servers': electrum!.map((e) => e.toJsonRequest()).toList(),
+      'electrum_servers': electrum!.map((e) => e.toJsonRequest()).toList(),
     },
     if (syncParams != null) 'sync_params': syncParams,
   };

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/zhtlc/zhtlc_rpc_namespace.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/zhtlc/zhtlc_rpc_namespace.dart
@@ -29,6 +29,25 @@ class ZhtlcMethodsNamespace extends BaseRpcMethodNamespace {
       ),
     );
   }
+
+  Future<UserActionResponse> sendUserAction({
+    required int taskId,
+    required String actionType,
+    required String pin,
+  }) {
+    return execute(
+      TaskEnableZhtlcUserAction(
+        taskId: taskId,
+        actionType: actionType,
+        pin: pin,
+        rpcPass: rpcPass,
+      ),
+    );
+  }
+
+  Future<ZhtlcCancelResponse> cancel({required int taskId}) {
+    return execute(TaskEnableZhtlcCancel(taskId: taskId, rpcPass: rpcPass));
+  }
 }
 
 // Also adding ZHTLC task requests:
@@ -83,4 +102,89 @@ class TaskEnableZhtlcStatus
   TaskStatusResponse parse(Map<String, dynamic> json) {
     return TaskStatusResponse.parse(json);
   }
+}
+
+class TaskEnableZhtlcUserAction
+    extends BaseRequest<UserActionResponse, GeneralErrorResponse> {
+  TaskEnableZhtlcUserAction({
+    required this.taskId,
+    required this.actionType,
+    required this.pin,
+    super.rpcPass,
+  }) : super(method: 'task::enable_z_coin::user_action', mmrpc: '2.0');
+
+  final int taskId;
+  final String actionType;
+  final String pin;
+
+  @override
+  JsonMap toJson() => {
+    ...super.toJson(),
+    'userpass': rpcPass,
+    'mmrpc': mmrpc,
+    'method': method,
+    'params': {
+      'task_id': taskId,
+      'user_action': {'action_type': actionType, 'pin': pin},
+    },
+  };
+
+  @override
+  UserActionResponse parse(Map<String, dynamic> json) {
+    return UserActionResponse.parse(json);
+  }
+}
+
+class TaskEnableZhtlcCancel
+    extends BaseRequest<ZhtlcCancelResponse, GeneralErrorResponse> {
+  TaskEnableZhtlcCancel({required this.taskId, super.rpcPass})
+    : super(method: 'task::enable_z_coin::cancel', mmrpc: '2.0');
+
+  final int taskId;
+
+  @override
+  JsonMap toJson() => {
+    ...super.toJson(),
+    'userpass': rpcPass,
+    'mmrpc': mmrpc,
+    'method': method,
+    'params': {'task_id': taskId},
+  };
+
+  @override
+  ZhtlcCancelResponse parse(Map<String, dynamic> json) {
+    return ZhtlcCancelResponse.parse(json);
+  }
+}
+
+class UserActionResponse extends BaseResponse {
+  UserActionResponse({required super.mmrpc, required this.result});
+
+  factory UserActionResponse.parse(JsonMap json) {
+    return UserActionResponse(
+      mmrpc: json.value<String>('mmrpc'),
+      result: json.value<String>('result'),
+    );
+  }
+
+  final String result;
+
+  @override
+  JsonMap toJson() => {'mmrpc': mmrpc, 'result': result};
+}
+
+class ZhtlcCancelResponse extends BaseResponse {
+  ZhtlcCancelResponse({required super.mmrpc, required this.result});
+
+  factory ZhtlcCancelResponse.parse(JsonMap json) {
+    return ZhtlcCancelResponse(
+      mmrpc: json.value<String>('mmrpc'),
+      result: json.value<String>('result'),
+    );
+  }
+
+  final String result;
+
+  @override
+  JsonMap toJson() => {'mmrpc': mmrpc, 'result': result};
 }

--- a/packages/komodo_defi_types/lib/src/protocols/zhtlc/zhtlc_protocol.dart
+++ b/packages/komodo_defi_types/lib/src/protocols/zhtlc/zhtlc_protocol.dart
@@ -23,7 +23,6 @@ class ZhtlcProtocol extends ProtocolClass {
 
   static void _validateZhtlcConfig(JsonMap json) {
     final requiredFields = {
-      // 'zcash_params_path': 'Zcash parameters path',
       'electrum': 'Electrum servers',
     };
 
@@ -37,8 +36,6 @@ class ZhtlcProtocol extends ProtocolClass {
     }
   }
 
-  String get zcashParamsPath =>
-
-      //TODO! config.value<String>('zcash_params_path');
-      'PLACEHOLDER_STRING_FOR_ZCASH_PARAMS_PATH';
+  String? get zcashParamsPath =>
+      config.valueOrNull<String>('zcash_params_path');
 }


### PR DESCRIPTION
## Summary
- add user action and cancel requests for ZHTLC activation
- serialize electrum servers with `electrum_servers`
- expose optional `zcash_params_path` in ZHTLC protocol

## Testing
- `flutter pub get --offline`
- `flutter analyze` *(fails: many unrelated issues)*

------
https://chatgpt.com/codex/tasks/task_e_6883738d09dc83268dd802273bc780c8