### PR TITLE
Adds change24hIfKnown for quick cache data access

### DIFF
--- a/packages/komodo_defi_sdk/lib/src/market_data/market_data_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/market_data/market_data_manager.dart
@@ -37,6 +37,12 @@ abstract class MarketDataManager {
     String fiatCurrency = 'usdt',
   });
 
+  /// Gets the 24-hour price change for an asset if it's cached, returns null otherwise
+  Decimal? change24hIfKnown(
+    AssetId assetId, {
+    String fiatCurrency = 'usdt',
+  });
+
   /// Gets historical fiat prices for an asset at specified dates
   ///
   /// Returns a map of dates to prices
@@ -144,6 +150,20 @@ class CexMarketDataManager implements MarketDataManager {
     );
 
     return _priceCache[cacheKey];
+  }
+
+  @override
+  Decimal? change24hIfKnown(
+    AssetId assetId, {
+    String fiatCurrency = 'usdt',
+  }) {
+    if (_isDisposed) {
+      throw StateError('PriceManager has been disposed');
+    }
+
+    final cacheKey = _getChangeCacheKey(assetId, fiatCurrency: fiatCurrency);
+
+    return _priceChangeCache[cacheKey];
   }
 
   @override


### PR DESCRIPTION
While working on https://github.com/KomodoPlatform/komodo-wallet/pull/2995 I noticed a lag between price and 24hr  change data. During subsequent investigations as to the cause of this delay, it was determined that it could be eliminated by adding `change24hIfKnown`, operating similar to `priceIfKnown`, thereby offering direct access to these values through the SDK rather than via the CoinsBloc state.

By decoupling from the CoinsBloc state, we should be able to avoid rebuilds of all coin widgets each time there is a change to price / 24hr change data. 

