### PR TITLE
feat(ui): add hero support for coin icons

### DIFF
--- a/packages/komodo_ui/lib/src/defi/asset/asset_icon.dart
+++ b/packages/komodo_ui/lib/src/defi/asset/asset_icon.dart
@@ -52,10 +52,16 @@ class AssetIcon extends StatelessWidget {
         size: size,
       ),
     );
+    
+    // Apply opacity first for disabled state
+    icon = Opacity(opacity: suspended ? disabledTheme.a : 1.0, child: icon);
+    
+    // Then wrap with Hero widget if provided (Hero should be outermost)
     if (heroTag != null) {
       icon = Hero(tag: heroTag!, child: icon);
     }
-    return Opacity(opacity: suspended ? disabledTheme.a : 1.0, child: icon);
+    
+    return icon;
   }
 
   /// Clears all caches used by [AssetIcon]

--- a/packages/komodo_ui/lib/src/defi/asset/asset_icon.dart
+++ b/packages/komodo_ui/lib/src/defi/asset/asset_icon.dart
@@ -13,6 +13,7 @@ class AssetIcon extends StatelessWidget {
     this.assetId, {
     this.size = 20,
     this.suspended = false,
+    this.heroTag,
     super.key,
   }) : _legacyTicker = null;
 
@@ -27,6 +28,7 @@ class AssetIcon extends StatelessWidget {
     String ticker, {
     this.size = 20,
     this.suspended = false,
+    this.heroTag,
     super.key,
   }) : _legacyTicker = ticker.toLowerCase(),
        assetId = null;
@@ -35,23 +37,25 @@ class AssetIcon extends StatelessWidget {
   final String? _legacyTicker;
   final double size;
   final bool suspended;
+  final Object? heroTag;
 
   String get _effectiveId => assetId?.id ?? _legacyTicker!;
 
   @override
   Widget build(BuildContext context) {
     final disabledTheme = Theme.of(context).disabledColor;
-    return Opacity(
-      opacity: suspended ? disabledTheme.a : 1.0,
-      child: SizedBox.square(
-        dimension: size,
-        child: _AssetIconResolver(
-          key: ValueKey(_effectiveId),
-          assetId: _effectiveId,
-          size: size,
-        ),
+    Widget icon = SizedBox.square(
+      dimension: size,
+      child: _AssetIconResolver(
+        key: ValueKey(_effectiveId),
+        assetId: _effectiveId,
+        size: size,
       ),
     );
+    if (heroTag != null) {
+      icon = Hero(tag: heroTag!, child: icon);
+    }
+    return Opacity(opacity: suspended ? disabledTheme.a : 1.0, child: icon);
   }
 
   /// Clears all caches used by [AssetIcon]

--- a/packages/komodo_ui/lib/src/defi/asset/asset_logo.dart
+++ b/packages/komodo_ui/lib/src/defi/asset/asset_logo.dart
@@ -100,6 +100,7 @@ class AssetLogo extends StatelessWidget {
         isBlank: isBlank,
         isDisabled: isDisabled,
         size: size,
+        heroTag: heroTag,
       );
     }
 
@@ -146,35 +147,43 @@ class _AssetLogoPlaceholder extends StatelessWidget {
     required this.isBlank,
     required this.isDisabled,
     required this.size,
+    this.heroTag,
   });
 
   final bool isBlank;
   final bool isDisabled;
   final double size;
+  final Object? heroTag;
 
   @override
   Widget build(BuildContext context) {
-    if (isBlank) {
-      return Container(
-        width: size,
-        height: size,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          color:
-              isDisabled
-                  ? Theme.of(context).disabledColor
-                  : Theme.of(context).colorScheme.secondaryContainer,
-        ),
-      );
+    final child =
+        isBlank
+            ? Container(
+              width: size,
+              height: size,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color:
+                    isDisabled
+                        ? Theme.of(context).disabledColor
+                        : Theme.of(context).colorScheme.secondaryContainer,
+              ),
+            )
+            : Icon(
+              Icons.monetization_on_outlined,
+              size: size,
+              color:
+                  isDisabled
+                      ? Theme.of(context).disabledColor
+                      : Theme.of(context).colorScheme.onSecondaryContainer,
+            );
+
+    if (heroTag != null) {
+      return Hero(tag: heroTag!, child: child);
     }
-    return Icon(
-      Icons.monetization_on_outlined,
-      size: size,
-      color:
-          isDisabled
-              ? Theme.of(context).disabledColor
-              : Theme.of(context).colorScheme.onSecondaryContainer,
-    );
+
+    return child;
   }
 }
 

--- a/packages/komodo_ui/lib/src/defi/asset/asset_logo.dart
+++ b/packages/komodo_ui/lib/src/defi/asset/asset_logo.dart
@@ -18,6 +18,7 @@ class AssetLogo extends StatelessWidget {
     this.asset, {
     this.size = 41,
     this.isDisabled = false,
+    this.heroTag,
     super.key,
   }) : _assetId = null,
        _legacyTicker = null,
@@ -28,6 +29,7 @@ class AssetLogo extends StatelessWidget {
     AssetId assetId, {
     this.size = 41,
     this.isDisabled = false,
+    this.heroTag,
     super.key,
   }) : asset = null,
        _assetId = assetId,
@@ -42,6 +44,7 @@ class AssetLogo extends StatelessWidget {
     String ticker, {
     this.size = 41,
     this.isDisabled = false,
+    this.heroTag,
     super.key,
   }) : _legacyTicker = ticker,
        asset = null,
@@ -59,6 +62,7 @@ class AssetLogo extends StatelessWidget {
     this.size = 41,
     this.isDisabled = false,
     this.isBlank = false,
+    this.heroTag,
     super.key,
   }) : asset = null,
        _assetId = null,
@@ -81,6 +85,9 @@ class AssetLogo extends StatelessWidget {
   /// Whether to display a blank placeholder instead of the default icon.
   /// Only used with the [AssetLogo.placeholder] constructor.
   final bool isBlank;
+
+  /// Optional tag for wrapping the icon in a [Hero] widget.
+  final Object? heroTag;
 
   @override
   Widget build(BuildContext context) {
@@ -105,12 +112,18 @@ class AssetLogo extends StatelessWidget {
 
     final mainIcon =
         resolvedId != null
-            ? AssetIcon(resolvedId, size: size, suspended: isDisabled)
+            ? AssetIcon(
+              resolvedId,
+              size: size,
+              suspended: isDisabled,
+              heroTag: heroTag,
+            )
             : (resolvedTicker != null
                 ? AssetIcon.ofTicker(
                   resolvedTicker,
                   size: size,
                   suspended: isDisabled,
+                  heroTag: heroTag,
                 )
                 : throw ArgumentError(
                   'resolvedTicker cannot be null when both asset and '


### PR DESCRIPTION
## Summary
- add optional heroTag argument to `AssetIcon`
- wire `AssetLogo` to pass heroTag to `AssetIcon`

## Testing
- `flutter pub get --offline`
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_6885809e306c8326ad8239408b6329ca