### PR TITLE
feat(pubkeys): add unbanning support

### DIFF
--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/rpc_methods.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/rpc_methods.dart
@@ -51,6 +51,7 @@ export 'wallet/get_wallet.dart';
 export 'wallet/get_wallet_names_request.dart';
 export 'wallet/get_wallet_names_response.dart';
 export 'wallet/my_balance.dart';
+export 'wallet/unban_pubkeys.dart';
 export 'withdrawal/send_raw_transaction_request.dart';
 export 'withdrawal/withdraw_request.dart';
 export 'withdrawal/withdrawal_rpc_namespace.dart';

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/wallet/unban_pubkeys.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/wallet/unban_pubkeys.dart
@@ -1,0 +1,105 @@
+import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+
+/// Determines how pubkeys should be unbanned
+enum UnbanType {
+  all,
+  few;
+
+  @override
+  String toString() => switch (this) {
+    UnbanType.all => 'All',
+    UnbanType.few => 'Few',
+  };
+
+  static UnbanType fromString(String value) {
+    return value.toLowerCase() == 'all' ? UnbanType.all : UnbanType.few;
+  }
+}
+
+/// Parameter for [UnbanPubkeysRequest]
+class UnbanBy {
+  const UnbanBy.all() : type = UnbanType.all, data = null;
+  const UnbanBy.few(this.data) : type = UnbanType.few;
+
+  final UnbanType type;
+  final List<String>? data;
+
+  JsonMap toJson() => {'type': type.toString(), if (data != null) 'data': data};
+}
+
+class UnbanPubkeysRequest
+    extends BaseRequest<UnbanPubkeysResponse, GeneralErrorResponse> {
+  UnbanPubkeysRequest({required String rpcPass, required this.unbanBy})
+    : super(method: 'unban_pubkeys', rpcPass: rpcPass, mmrpc: null);
+
+  final UnbanBy unbanBy;
+
+  @override
+  JsonMap toJson() => {...super.toJson(), 'unban_by': unbanBy.toJson()};
+
+  @override
+  UnbanPubkeysResponse parse(JsonMap json) => UnbanPubkeysResponse.parse(json);
+}
+
+class UnbanPubkeysResponse extends BaseResponse {
+  UnbanPubkeysResponse({required super.mmrpc, required this.result});
+
+  factory UnbanPubkeysResponse.parse(JsonMap json) => UnbanPubkeysResponse(
+    mmrpc: json.valueOrNull<String>('mmrpc'),
+    result: UnbanPubkeysResult.fromJson(json.value<JsonMap>('result')),
+  );
+
+  final UnbanPubkeysResult result;
+
+  @override
+  JsonMap toJson() => {'mmrpc': mmrpc, 'result': result.toJson()};
+}
+
+class UnbanPubkeysResult {
+  UnbanPubkeysResult({
+    required this.stillBanned,
+    required this.unbanned,
+    required this.wereNotBanned,
+  });
+
+  factory UnbanPubkeysResult.fromJson(JsonMap json) {
+    final still = json.valueOrNull<JsonMap>('still_banned') ?? {};
+    final unbanned = json.valueOrNull<JsonMap>('unbanned') ?? {};
+    return UnbanPubkeysResult(
+      stillBanned: still.map(
+        (k, v) => MapEntry(k, BannedPubkeyInfo.fromJson(v as JsonMap)),
+      ),
+      unbanned: unbanned.map(
+        (k, v) => MapEntry(k, BannedPubkeyInfo.fromJson(v as JsonMap)),
+      ),
+      wereNotBanned:
+          (json.valueOrNull<List<dynamic>>('were_not_banned') ?? [])
+              .cast<String>(),
+    );
+  }
+
+  final Map<String, BannedPubkeyInfo> stillBanned;
+  final Map<String, BannedPubkeyInfo> unbanned;
+  final List<String> wereNotBanned;
+
+  JsonMap toJson() => {
+    'still_banned': stillBanned.map((k, v) => MapEntry(k, v.toJson())),
+    'unbanned': unbanned.map((k, v) => MapEntry(k, v.toJson())),
+    'were_not_banned': wereNotBanned,
+  };
+}
+
+class BannedPubkeyInfo {
+  const BannedPubkeyInfo({required this.type, required this.reason});
+
+  factory BannedPubkeyInfo.fromJson(JsonMap json) => BannedPubkeyInfo(
+    type: json.value<String>('type'),
+    reason: json.value<String>('reason'),
+  );
+
+  final String type;
+  final String reason;
+
+  JsonMap toJson() => {'type': type, 'reason': reason};
+}

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/wallet/unban_pubkeys.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/wallet/unban_pubkeys.dart
@@ -13,7 +13,14 @@ enum UnbanType {
   };
 
   static UnbanType fromString(String value) {
-    return value.toLowerCase() == 'all' ? UnbanType.all : UnbanType.few;
+    final lowerValue = value.toLowerCase();
+    if (lowerValue == 'all') {
+      return UnbanType.all;
+    } else if (lowerValue == 'few') {
+      return UnbanType.few;
+    } else {
+      throw ArgumentError('Invalid UnbanType value: $value. Expected "all" or "few".');
+    }
   }
 }
 

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/wallet/unban_pubkeys.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/wallet/unban_pubkeys.dart
@@ -1,3 +1,4 @@
+import 'package:equatable/equatable.dart';
 import 'package:komodo_defi_rpc_methods/src/internal_exports.dart';
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 
@@ -12,20 +13,22 @@ enum UnbanType {
     UnbanType.few => 'Few',
   };
 
-  static UnbanType fromString(String value) {
+  static UnbanType parse(String value) {
     final lowerValue = value.toLowerCase();
     if (lowerValue == 'all') {
       return UnbanType.all;
     } else if (lowerValue == 'few') {
       return UnbanType.few;
     } else {
-      throw ArgumentError('Invalid UnbanType value: $value. Expected "all" or "few".');
+      throw ArgumentError(
+        'Invalid UnbanType value: $value. Expected "all" or "few".',
+      );
     }
   }
 }
 
 /// Parameter for [UnbanPubkeysRequest]
-class UnbanBy {
+class UnbanBy extends Equatable {
   const UnbanBy.all() : type = UnbanType.all, data = null;
   const UnbanBy.few(this.data) : type = UnbanType.few;
 
@@ -33,6 +36,9 @@ class UnbanBy {
   final List<String>? data;
 
   JsonMap toJson() => {'type': type.toString(), if (data != null) 'data': data};
+
+  @override
+  List<Object?> get props => [type, data];
 }
 
 class UnbanPubkeysRequest
@@ -63,8 +69,8 @@ class UnbanPubkeysResponse extends BaseResponse {
   JsonMap toJson() => {'mmrpc': mmrpc, 'result': result.toJson()};
 }
 
-class UnbanPubkeysResult {
-  UnbanPubkeysResult({
+class UnbanPubkeysResult extends Equatable {
+  const UnbanPubkeysResult({
     required this.stillBanned,
     required this.unbanned,
     required this.wereNotBanned,
@@ -95,9 +101,12 @@ class UnbanPubkeysResult {
     'unbanned': unbanned.map((k, v) => MapEntry(k, v.toJson())),
     'were_not_banned': wereNotBanned,
   };
+
+  @override
+  List<Object?> get props => [stillBanned, unbanned, wereNotBanned];
 }
 
-class BannedPubkeyInfo {
+class BannedPubkeyInfo extends Equatable {
   const BannedPubkeyInfo({required this.type, required this.reason});
 
   factory BannedPubkeyInfo.fromJson(JsonMap json) => BannedPubkeyInfo(
@@ -109,4 +118,7 @@ class BannedPubkeyInfo {
   final String reason;
 
   JsonMap toJson() => {'type': type, 'reason': reason};
+
+  @override
+  List<Object?> get props => [type, reason];
 }

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods_library.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods_library.dart
@@ -98,6 +98,11 @@ class WalletMethods extends BaseRpcMethodNamespace {
 
   Future<GetPublicKeyHashResponse> getPublicKeyHash([String? rpcPass]) =>
       execute(GetPublicKeyHashRequest(rpcPass: rpcPass));
+
+  Future<UnbanPubkeysResponse> unbanPubkeys({
+    required UnbanBy unbanBy,
+    String? rpcPass,
+  }) => execute(UnbanPubkeysRequest(rpcPass: rpcPass ?? '', unbanBy: unbanBy));
 }
 
 /// KDF v2 Utility Methods not specific to any larger feature

--- a/packages/komodo_defi_sdk/example/lib/screens/asset_page.dart
+++ b/packages/komodo_defi_sdk/example/lib/screens/asset_page.dart
@@ -176,6 +176,7 @@ class _AssetHeaderState extends State<AssetHeader> {
 
   String? _signedMessage;
   bool _isSigningMessage = false;
+  bool _isUnbanning = false;
   KdfUser? _currentUser;
 
   Future<void> _loadCurrentUser() async {
@@ -218,6 +219,24 @@ class _AssetHeaderState extends State<AssetHeader> {
         ],
       ],
     );
+  }
+
+  Future<void> _unbanPubkeys() async {
+    setState(() => _isUnbanning = true);
+    try {
+      final result = await context.read<KomodoDefiSdk>().pubkeys.unbanPubkeys(
+        const UnbanBy.all(),
+      );
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Unbanned ${result.unbanned.length} pubkeys')),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Error: $e')));
+    } finally {
+      if (mounted) setState(() => _isUnbanning = false);
+    }
   }
 
   Widget _buildBalanceOverview(BuildContext context) {
@@ -363,6 +382,12 @@ class _AssetHeaderState extends State<AssetHeader> {
           onPressed: () {},
           icon: const Icon(Icons.qr_code),
           label: const Text('Receive'),
+        ),
+        FilledButton.tonalIcon(
+          onPressed: _isUnbanning ? null : _unbanPubkeys,
+          icon: const Icon(Icons.lock_open),
+          label:
+              _isUnbanning ? const Text('Unbanning...') : const Text('Unban'),
         ),
 
         Tooltip(

--- a/packages/komodo_defi_sdk/lib/src/pubkeys/pubkey_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/pubkeys/pubkey_manager.dart
@@ -1,5 +1,6 @@
 import 'package:komodo_defi_local_auth/komodo_defi_local_auth.dart';
 import 'package:komodo_defi_sdk/src/_internal_exports.dart';
+import 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart';
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 
@@ -41,6 +42,12 @@ class PubkeyManager {
       return;
     }
     yield* strategy.getNewAddressStream(asset.id, _client);
+  }
+
+  /// Unban pubkeys according to [unbanBy] criteria
+  Future<UnbanPubkeysResult> unbanPubkeys(UnbanBy unbanBy) async {
+    final response = await _client.rpc.wallet.unbanPubkeys(unbanBy: unbanBy);
+    return response.result;
   }
 
   Future<PubkeyStrategy> _resolvePubkeyStrategy(Asset asset) async {

--- a/packages/komodo_defi_types/lib/src/exported_rpc_types.dart
+++ b/packages/komodo_defi_types/lib/src/exported_rpc_types.dart
@@ -1,2 +1,2 @@
 export 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart'
-    show AddressFormat, BalanceInfo;
+    show AddressFormat, BalanceInfo, UnbanBy, UnbanPubkeysResult, BannedPubkeyInfo;


### PR DESCRIPTION
## Summary
- add `unban_pubkeys` RPC request/response
- expose `unbanPubkeys` through wallet RPC methods
- add `unbanPubkeys` to `PubkeyManager`
- show Unban button in the example app

## Testing
- `flutter pub get --offline`
- `dart format .`
- `flutter analyze` *(fails: 2463 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68877f2899c883269af084e6a018df3f