### PR TITLE
chore: remove unused WithdrawResult import

### DIFF
--- a/packages/komodo_defi_types/lib/src/migration/migration_preview.dart
+++ b/packages/komodo_defi_types/lib/src/migration/migration_preview.dart
@@ -1,7 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart'
-    show WithdrawResult, WalletId, WithdrawalPreview;
+    show WalletId, WithdrawalPreview;
 
 part 'migration_preview.freezed.dart';
 part 'migration_preview.g.dart';

--- a/packages/komodo_defi_types/lib/src/migration/migration_preview.g.dart
+++ b/packages/komodo_defi_types/lib/src/migration/migration_preview.g.dart
@@ -14,7 +14,7 @@ _MigrationPreview _$MigrationPreviewFromJson(Map<String, dynamic> json) =>
           WalletId.fromJson(json['to_wallet_id'] as Map<String, dynamic>),
       pubkeyHash: json['pubkey_hash'] as String,
       withdrawals: (json['withdrawals'] as List<dynamic>)
-          .map((e) => WithdrawResult.fromJson(e as Map<String, dynamic>))
+          .map((e) => WithdrawalPreview.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 


### PR DESCRIPTION
## Summary
- remove unused WithdrawResult import from migration preview
- ensure generated preview uses WithdrawalPreview

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6890c03b45d8833188368c3aab6ac4df