### PR TITLE
fix: enable explicit toJson for migration preview

### DIFF
--- a/packages/komodo_defi_types/lib/src/migration/migration_preview.dart
+++ b/packages/komodo_defi_types/lib/src/migration/migration_preview.dart
@@ -8,7 +8,7 @@ part 'migration_preview.g.dart';
 
 @freezed
 abstract class MigrationPreview with _$MigrationPreview {
-  @JsonSerializable(fieldRename: FieldRename.snake)
+  @JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
   const factory MigrationPreview({
     required WalletId fromWalletId,
     required WalletId toWalletId,

--- a/packages/komodo_defi_types/lib/src/migration/migration_preview.freezed.dart
+++ b/packages/komodo_defi_types/lib/src/migration/migration_preview.freezed.dart
@@ -276,7 +276,7 @@ extension MigrationPreviewPatterns on MigrationPreview {
 
 /// @nodoc
 
-@JsonSerializable(fieldRename: FieldRename.snake)
+@JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
 class _MigrationPreview implements MigrationPreview {
   const _MigrationPreview(
       {required this.fromWalletId,

--- a/packages/komodo_defi_types/lib/src/migration/migration_preview.g.dart
+++ b/packages/komodo_defi_types/lib/src/migration/migration_preview.g.dart
@@ -20,8 +20,8 @@ _MigrationPreview _$MigrationPreviewFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$MigrationPreviewToJson(_MigrationPreview instance) =>
     <String, dynamic>{
-      'from_wallet_id': instance.fromWalletId,
-      'to_wallet_id': instance.toWalletId,
+      'from_wallet_id': instance.fromWalletId.toJson(),
+      'to_wallet_id': instance.toWalletId.toJson(),
       'pubkey_hash': instance.pubkeyHash,
-      'withdrawals': instance.withdrawals,
+      'withdrawals': instance.withdrawals.map((e) => e.toJson()).toList(),
     };


### PR DESCRIPTION
## Summary
- enable explicitToJson on `MigrationPreview` to serialize nested IDs and withdrawals
- regenerate `migration_preview` Freezed and JSON files to remove manual edits

## Testing
- `dart run build_runner build --delete-conflicting-outputs`
- `dart analyze` (116 info issues)
- `dart test` *(fails: type '(invalid-type, CupertinoUserInterfaceLevelData, bool)' is not exhaustively matched)*

------
https://chatgpt.com/codex/tasks/task_e_6890e71b3f908331bf5435a5e486b342