### PR TITLE
refactor: enable DI for market data

### DIFF
--- a/packages/komodo_cex_market_data/lib/src/binance/data/binance_repository.dart
+++ b/packages/komodo_cex_market_data/lib/src/binance/data/binance_repository.dart
@@ -13,12 +13,10 @@ import 'package:komodo_defi_types/komodo_defi_types.dart';
 
 // Declaring constants here to make this easier to copy & move around
 /// The base URL for the Binance API.
-List<String> get binanceApiEndpoint =>
-    ['https://api.binance.com/api/v3', 'https://api.binance.us/api/v3'];
-
-BinanceRepository binanceRepository = BinanceRepository(
-  binanceProvider: const BinanceProvider(),
-);
+List<String> get binanceApiEndpoint => [
+  'https://api.binance.com/api/v3',
+  'https://api.binance.us/api/v3',
+];
 
 /// A repository class for interacting with the Binance API.
 /// This class provides methods to fetch legacy tickers and OHLC candle data.
@@ -27,12 +25,11 @@ class BinanceRepository implements CexRepository {
   BinanceRepository({
     required IBinanceProvider binanceProvider,
     BackoffStrategy? defaultBackoffStrategy,
-  })  : _binanceProvider = binanceProvider,
-        _defaultBackoffStrategy = defaultBackoffStrategy ??
-            ExponentialBackoff(
-              maxDelay: const Duration(seconds: 5),
-            ),
-        _idResolutionStrategy = BinanceIdResolutionStrategy();
+  }) : _binanceProvider = binanceProvider,
+       _defaultBackoffStrategy =
+           defaultBackoffStrategy ??
+           ExponentialBackoff(maxDelay: const Duration(seconds: 5)),
+       _idResolutionStrategy = BinanceIdResolutionStrategy();
 
   final IBinanceProvider _binanceProvider;
   final BackoffStrategy _defaultBackoffStrategy;
@@ -213,11 +210,11 @@ class BinanceRepository implements CexRepository {
         backoffStrategy: backoffStrategy,
       );
 
-      final batchResult =
-          ohlcData.ohlc.fold<Map<DateTime, double>>({}, (map, ohlc) {
-        final date = DateTime.fromMillisecondsSinceEpoch(
-          ohlc.closeTime,
-        );
+      final batchResult = ohlcData.ohlc.fold<Map<DateTime, double>>({}, (
+        map,
+        ohlc,
+      ) {
+        final date = DateTime.fromMillisecondsSinceEpoch(ohlc.closeTime);
         map[DateTime(date.year, date.month, date.day)] = ohlc.close;
         return map;
       });

--- a/packages/komodo_cex_market_data/lib/src/coingecko/data/coingecko_cex_provider.dart
+++ b/packages/komodo_cex_market_data/lib/src/coingecko/data/coingecko_cex_provider.dart
@@ -4,8 +4,55 @@ import 'package:http/http.dart' as http;
 import 'package:komodo_cex_market_data/komodo_cex_market_data.dart';
 import 'package:komodo_cex_market_data/src/coingecko/models/coin_historical_data/coin_historical_data.dart';
 
+/// Interface for fetching data from CoinGecko API.
+abstract class ICoinGeckoProvider {
+  Future<List<CexCoin>> fetchCoinList({bool includePlatforms = false});
+
+  Future<List<String>> fetchSupportedVsCurrencies();
+
+  Future<List<CoinMarketData>> fetchCoinMarketData({
+    String vsCurrency = 'usd',
+    List<String>? ids,
+    String? category,
+    String order = 'market_cap_asc',
+    int perPage = 100,
+    int page = 1,
+    bool sparkline = false,
+    String? priceChangePercentage,
+    String locale = 'en',
+    String? precision,
+  });
+
+  Future<CoinMarketChart> fetchCoinMarketChart({
+    required String id,
+    required String vsCurrency,
+    required int fromUnixTimestamp,
+    required int toUnixTimestamp,
+    String? precision,
+  });
+
+  Future<CoinOhlc> fetchCoinOhlc(
+    String id,
+    String vsCurrency,
+    int days, {
+    int? precision,
+  });
+
+  Future<CoinHistoricalData> fetchCoinHistoricalMarketData({
+    required String id,
+    required DateTime date,
+    String vsCurrency = 'usd',
+    bool localization = false,
+  });
+
+  Future<Map<String, CexPrice>> fetchCoinPrices(
+    List<String> coinGeckoIds, {
+    List<String> vsCurrencies = const <String>['usd'],
+  });
+}
+
 /// A class for fetching data from CoinGecko API.
-class CoinGeckoCexProvider {
+class CoinGeckoCexProvider implements ICoinGeckoProvider {
   /// Creates a new instance of [CoinGeckoCexProvider].
   CoinGeckoCexProvider({
     this.baseUrl = 'api.coingecko.com',
@@ -45,8 +92,10 @@ class CoinGeckoCexProvider {
 
   /// Fetches the list of supported vs currencies.
   Future<List<String>> fetchSupportedVsCurrencies() async {
-    final uri =
-        Uri.https(baseUrl, '$apiVersion/simple/supported_vs_currencies');
+    final uri = Uri.https(
+      baseUrl,
+      '$apiVersion/simple/supported_vs_currencies',
+    );
 
     final response = await http.get(uri);
     if (response.statusCode == 200) {
@@ -96,8 +145,11 @@ class CoinGeckoCexProvider {
       'locale': locale,
       if (precision != null) 'price_change_percentage': precision,
     };
-    final uri =
-        Uri.https(baseUrl, '$apiVersion/coins/markets', queryParameters);
+    final uri = Uri.https(
+      baseUrl,
+      '$apiVersion/coins/markets',
+      queryParameters,
+    );
 
     return http.get(uri).then((http.Response response) {
       if (response.statusCode == 200) {

--- a/packages/komodo_cex_market_data/lib/src/coingecko/data/coingecko_repository.dart
+++ b/packages/komodo_cex_market_data/lib/src/coingecko/data/coingecko_repository.dart
@@ -23,7 +23,7 @@ class CoinGeckoRepository implements CexRepository {
         _idResolutionStrategy = CoinGeckoIdResolutionStrategy();
 
   /// The CoinGecko provider to use for fetching data.
-  final CoinGeckoCexProvider coinGeckoProvider;
+  final ICoinGeckoProvider coinGeckoProvider;
   final BackoffStrategy _defaultBackoffStrategy;
   final IdResolutionStrategy _idResolutionStrategy;
 

--- a/packages/komodo_cex_market_data/lib/src/coingecko/data/sparkline_repository.dart
+++ b/packages/komodo_cex_market_data/lib/src/coingecko/data/sparkline_repository.dart
@@ -8,10 +8,11 @@ import 'package:komodo_cex_market_data/komodo_cex_market_data.dart';
 SparklineRepository sparklineRepository = SparklineRepository();
 
 class SparklineRepository {
-  SparklineRepository() {
-    _binanceRepository = binanceRepository;
-  }
-  late BinanceRepository _binanceRepository;
+  SparklineRepository({BinanceRepository? binanceRepository})
+    : _binanceRepository =
+          binanceRepository ??
+          BinanceRepository(binanceProvider: const BinanceProvider());
+  final BinanceRepository _binanceRepository;
   bool isInitialized = false;
   final Duration cacheExpiry = const Duration(hours: 1);
 

--- a/packages/komodo_cex_market_data/lib/src/komodo/prices/komodo_price_provider.dart
+++ b/packages/komodo_cex_market_data/lib/src/komodo/prices/komodo_price_provider.dart
@@ -4,8 +4,13 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:komodo_cex_market_data/src/models/models.dart';
 
+/// Interface for fetching prices from Komodo API.
+abstract class IKomodoPriceProvider {
+  Future<Map<String, CexPrice>> getKomodoPrices();
+}
+
 /// A class for fetching prices from Komodo API.
-class KomodoPriceProvider {
+class KomodoPriceProvider implements IKomodoPriceProvider {
   /// Creates a new instance of [KomodoPriceProvider].
   KomodoPriceProvider({
     this.mainTickersUrl =
@@ -42,8 +47,10 @@ class KomodoPriceProvider {
 
     final prices = <String, CexPrice>{};
     json.forEach((String priceTicker, dynamic pricesData) {
-      prices[priceTicker] =
-          CexPrice.fromJson(priceTicker, pricesData as Map<String, dynamic>);
+      prices[priceTicker] = CexPrice.fromJson(
+        priceTicker,
+        pricesData as Map<String, dynamic>,
+      );
     });
     return prices;
   }

--- a/packages/komodo_cex_market_data/pubspec.yaml
+++ b/packages/komodo_cex_market_data/pubspec.yaml
@@ -20,4 +20,5 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^6.0.0 # flutter.dev
+  mocktail: ^1.0.4
   test: ^1.25.7

--- a/packages/komodo_cex_market_data/test/komodo_price_repository_test.dart
+++ b/packages/komodo_cex_market_data/test/komodo_price_repository_test.dart
@@ -1,0 +1,55 @@
+import 'package:komodo_cex_market_data/komodo_cex_market_data.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockKomodoPriceProvider extends Mock implements IKomodoPriceProvider {}
+
+void main() {
+  group('KomodoPriceRepository', () {
+    late MockKomodoPriceProvider provider;
+    late KomodoPriceRepository repository;
+
+    setUp(() {
+      provider = MockKomodoPriceProvider();
+      repository = KomodoPriceRepository(cexPriceProvider: provider);
+    });
+
+    AssetId asset(String id) => AssetId(
+      id: id,
+      name: id,
+      symbol: AssetSymbol(assetConfigId: id),
+      chainId: AssetChainId(chainId: 0),
+      derivationPath: null,
+      subClass: CoinSubClass.utxo,
+    );
+
+    test('supports returns true for supported asset and fiat', () async {
+      when(
+        () => provider.getKomodoPrices(),
+      ).thenAnswer((_) async => {'KMD': CexPrice(ticker: 'KMD', price: 1.0)});
+
+      final result = await repository.supports(
+        asset('KMD'),
+        AssetId.fromFiatTicker('usd'),
+        PriceRequestType.currentPrice,
+      );
+
+      expect(result, isTrue);
+    });
+
+    test('supports returns false for unsupported asset', () async {
+      when(
+        () => provider.getKomodoPrices(),
+      ).thenAnswer((_) async => {'BTC': CexPrice(ticker: 'BTC', price: 1.0)});
+
+      final result = await repository.supports(
+        asset('KMD'),
+        AssetId.fromFiatTicker('usd'),
+        PriceRequestType.currentPrice,
+      );
+
+      expect(result, isFalse);
+    });
+  });
+}

--- a/packages/komodo_cex_market_data/test/repository_selection_strategy_test.dart
+++ b/packages/komodo_cex_market_data/test/repository_selection_strategy_test.dart
@@ -1,0 +1,66 @@
+import 'package:komodo_cex_market_data/komodo_cex_market_data.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockBinanceRepository extends Mock implements BinanceRepository {}
+
+class MockCoinGeckoRepository extends Mock implements CoinGeckoRepository {}
+
+void main() {
+  group('RepositorySelectionStrategy', () {
+    late RepositorySelectionStrategy strategy;
+    late MockBinanceRepository binance;
+    late MockCoinGeckoRepository gecko;
+
+    setUp(() {
+      strategy = DefaultRepositorySelectionStrategy();
+      binance = MockBinanceRepository();
+      gecko = MockCoinGeckoRepository();
+    });
+
+    test('selects repository based on priority', () async {
+      final asset = AssetId(
+        id: 'BTC',
+        name: 'BTC',
+        symbol: AssetSymbol(assetConfigId: 'BTC'),
+        chainId: AssetChainId(chainId: 0),
+        derivationPath: null,
+        subClass: CoinSubClass.utxo,
+      );
+      final fiat = AssetId.fromFiatTicker('usd');
+
+      when(() => binance.getCoinList()).thenAnswer(
+        (_) async => [
+          CexCoin(
+            id: 'BTC',
+            symbol: 'BTC',
+            name: 'BTC',
+            currencies: {'USD'},
+            source: 'binance',
+          ),
+        ],
+      );
+      when(() => gecko.getCoinList()).thenAnswer(
+        (_) async => [
+          CexCoin(
+            id: 'BTC',
+            symbol: 'BTC',
+            name: 'BTC',
+            currencies: {'USD'},
+            source: 'gecko',
+          ),
+        ],
+      );
+
+      final repo = await strategy.selectRepository(
+        assetId: asset,
+        fiatAssetId: fiat,
+        requestType: PriceRequestType.currentPrice,
+        availableRepositories: [gecko, binance],
+      );
+
+      expect(repo, equals(binance));
+    });
+  });
+}

--- a/packages/komodo_defi_sdk/test/market_data_manager_test.dart
+++ b/packages/komodo_defi_sdk/test/market_data_manager_test.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+
+import 'package:decimal/decimal.dart';
+import 'package:komodo_cex_market_data/komodo_cex_market_data.dart';
+import 'package:komodo_defi_sdk/src/market_data/market_data_manager.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockKomodoPriceRepository extends Mock
+    implements IKomodoPriceRepository {}
+
+class MockCexRepository extends Mock implements CexRepository {}
+
+void main() {
+  group('CexMarketDataManager', () {
+    AssetId asset(String id) => AssetId(
+      id: id,
+      name: id,
+      symbol: AssetSymbol(assetConfigId: id),
+      chainId: AssetChainId(chainId: 0),
+      derivationPath: null,
+      subClass: CoinSubClass.utxo,
+    );
+
+    test('prefers KomodoPriceRepository when supported', () async {
+      final komodo = MockKomodoPriceRepository();
+      final fallback = MockCexRepository();
+      final manager = CexMarketDataManager(
+        priceRepositories: [fallback],
+        komodoPriceRepository: komodo,
+        selectionStrategy: DefaultRepositorySelectionStrategy(),
+        timerFactory: (d, cb) => Timer(d, cb),
+      );
+
+      when(() => komodo.getCoinList()).thenAnswer(
+        (_) async => [
+          CexCoin(
+            id: 'BTC',
+            symbol: 'BTC',
+            name: 'BTC',
+            currencies: {'USDT'},
+            source: 'komodo',
+          ),
+        ],
+      );
+      when(
+        () => komodo.getCoinFiatPrice(
+          asset('BTC'),
+          priceDate: null,
+          fiatCoinId: 'usdt',
+        ),
+      ).thenAnswer((_) async => 2.0);
+      when(() => fallback.getCoinList()).thenAnswer(
+        (_) async => [
+          CexCoin(
+            id: 'BTC',
+            symbol: 'BTC',
+            name: 'BTC',
+            currencies: {'USDT'},
+            source: 'fallback',
+          ),
+        ],
+      );
+      when(
+        () => fallback.getCoinFiatPrice(
+          asset('BTC'),
+          priceDate: null,
+          fiatCoinId: 'usdt',
+        ),
+      ).thenAnswer((_) async => 3.0);
+
+      await manager.init();
+      final price = await manager.fiatPrice(asset('BTC'));
+      expect(price, Decimal.parse('2.0'));
+      verify(
+        () => komodo.getCoinFiatPrice(
+          asset('BTC'),
+          priceDate: null,
+          fiatCoinId: 'usdt',
+        ),
+      ).called(1);
+      verifyNever(
+        () => fallback.getCoinFiatPrice(
+          asset('BTC'),
+          priceDate: null,
+          fiatCoinId: 'usdt',
+        ),
+      );
+    });
+
+    test(
+      'falls back when Komodo repository unsupported and caches results',
+      () async {
+        final komodo = MockKomodoPriceRepository();
+        final fallback = MockCexRepository();
+        final manager = CexMarketDataManager(
+          priceRepositories: [fallback],
+          komodoPriceRepository: komodo,
+          selectionStrategy: DefaultRepositorySelectionStrategy(),
+          timerFactory: (d, cb) => Timer(d, cb),
+        );
+
+        when(() => komodo.getCoinList()).thenAnswer((_) async => []);
+        when(() => fallback.getCoinList()).thenAnswer(
+          (_) async => [
+            CexCoin(
+              id: 'BTC',
+              symbol: 'BTC',
+              name: 'BTC',
+              currencies: {'USDT'},
+              source: 'fallback',
+            ),
+          ],
+        );
+        when(
+          () => fallback.getCoinFiatPrice(
+            asset('BTC'),
+            priceDate: null,
+            fiatCoinId: 'usdt',
+          ),
+        ).thenAnswer((_) async => 3.0);
+
+        await manager.init();
+        final first = await manager.fiatPrice(asset('BTC'));
+        final second = await manager.fiatPrice(asset('BTC'));
+
+        expect(first, Decimal.parse('3.0'));
+        expect(second, Decimal.parse('3.0'));
+        verify(
+          () => fallback.getCoinFiatPrice(
+            asset('BTC'),
+            priceDate: null,
+            fiatCoinId: 'usdt',
+          ),
+        ).called(1);
+
+        await manager.dispose();
+        expect(() => manager.priceIfKnown(asset('BTC')), throwsStateError);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add provider/repository interfaces for market data
- inject selection strategy and timer into market data manager
- add unit tests for selection strategy, Komodo price repository and market data manager
- fix test asset definitions and fiat currency to allow tests to run under flutter environment

## Testing
- `flutter test test/komodo_price_repository_test.dart test/repository_selection_strategy_test.dart` (packages/komodo_cex_market_data)
- `flutter test test/market_data_manager_test.dart` (packages/komodo_defi_sdk)


------
https://chatgpt.com/codex/tasks/task_e_6891d3bdf3388331a0948dce086396cc