### PR TITLE
feat(example): integrate dragon logs

### DIFF
--- a/packages/komodo_defi_sdk/example/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/komodo_defi_sdk/example/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/packages/komodo_defi_sdk/example/linux/flutter/generated_plugins.cmake
+++ b/packages/komodo_defi_sdk/example/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/packages/komodo_defi_sdk/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/komodo_defi_sdk/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import flutter_secure_storage_darwin
 import local_auth_darwin
 import mobile_scanner
 import path_provider_foundation
+import share_plus
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -16,5 +17,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLALocalAuthPlugin.register(with: registry.registrar(forPlugin: "FLALocalAuthPlugin"))
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/packages/komodo_defi_sdk/example/pubspec.lock
+++ b/packages/komodo_defi_sdk/example/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -81,6 +89,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  dragon_logs:
+    dependency: "direct main"
+    description:
+      path: "../../dragon_logs"
+      relative: true
+    source: path
+    version: "1.2.0"
   equatable:
     dependency: "direct main"
     description:
@@ -147,6 +162,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -469,6 +489,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   mobile_scanner:
     dependency: transitive
     description:
@@ -589,6 +617,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
+  share_plus:
+    dependency: transitive
+    description:
+      name: share_plus
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   shared_preferences:
     dependency: transitive
     description:
@@ -722,6 +766,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   uuid:
     dependency: transitive
     description:

--- a/packages/komodo_defi_sdk/example/pubspec.yaml
+++ b/packages/komodo_defi_sdk/example/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   flutter_bloc: ^9.1.1
   flutter_secure_storage: ^10.0.0-beta.4
 
+  dragon_logs:
+    path: ../../dragon_logs
   komodo_defi_sdk:
     path: ../
 

--- a/packages/komodo_defi_sdk/example/pubspec_overrides.yaml
+++ b/packages/komodo_defi_sdk/example/pubspec_overrides.yaml
@@ -1,5 +1,7 @@
-# melos_managed_dependency_overrides: komodo_cex_market_data,komodo_coin_updates,komodo_coins,komodo_defi_framework,komodo_defi_local_auth,komodo_defi_rpc_methods,komodo_defi_sdk,komodo_defi_types,komodo_ui,komodo_wallet_build_transformer
+# melos_managed_dependency_overrides: dragon_logs,komodo_cex_market_data,komodo_coin_updates,komodo_coins,komodo_defi_framework,komodo_defi_local_auth,komodo_defi_rpc_methods,komodo_defi_sdk,komodo_defi_types,komodo_ui,komodo_wallet_build_transformer
 dependency_overrides:
+  dragon_logs:
+    path: ../../dragon_logs
   komodo_cex_market_data:
     path: ../../komodo_cex_market_data
   komodo_coin_updates:

--- a/packages/komodo_defi_sdk/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/komodo_defi_sdk/example/windows/flutter/generated_plugin_registrant.cc
@@ -8,10 +8,16 @@
 
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <local_auth_windows/local_auth_plugin.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   LocalAuthPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("LocalAuthPlugin"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/packages/komodo_defi_sdk/example/windows/flutter/generated_plugins.cmake
+++ b/packages/komodo_defi_sdk/example/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,8 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
   local_auth_windows
+  share_plus
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## Summary
- integrate dragon_logs into the SDK example app and expose a log export option

## Testing
- `flutter analyze | tail -n 20`
- `flutter test packages/dragon_logs/test` *(fails: cannot run without a dependency on either "package:flutter_test" or "package:test")*

------
https://chatgpt.com/codex/tasks/task_e_68925d6fb2248326b81cf5558d1745cf