### PR TITLE
Replace proprietary native code with open source

### DIFF
--- a/products/dex_dungeon/lib/app/view/app.dart
+++ b/products/dex_dungeon/lib/app/view/app.dart
@@ -4,7 +4,6 @@ import 'package:dex_dungeon/loading/loading.dart';
 import 'package:flame/cache.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:google_fonts/google_fonts.dart';
 
 class App extends StatelessWidget {
   const App({super.key});
@@ -43,7 +42,8 @@ class AppView extends StatelessWidget {
             backgroundColor: WidgetStateProperty.all(const Color(0xFF2A48DF)),
           ),
         ),
-        textTheme: GoogleFonts.poppinsTextTheme(),
+        // Use default Material text theme to avoid proprietary font fetchers
+        textTheme: Typography.blackMountainView,
       ),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,

--- a/products/dex_dungeon/pubspec.lock
+++ b/products/dex_dungeon/pubspec.lock
@@ -389,14 +389,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
-  google_fonts:
-    dependency: "direct main"
-    description:
-      name: google_fonts
-      sha256: b1ac0fe2832c9cc95e5e88b57d627c5e68c223b9657f4b96e1487aa9098c7b82
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.2.1"
   hive:
     dependency: transitive
     description:
@@ -516,20 +508,6 @@ packages:
     dependency: transitive
     description:
       path: "../../packages/komodo_defi_rpc_methods"
-      relative: true
-    source: path
-    version: "0.3.0+0"
-  komodo_defi_sdk:
-    dependency: "direct main"
-    description:
-      path: "../../packages/komodo_defi_sdk"
-      relative: true
-    source: path
-    version: "0.3.0+0"
-  komodo_defi_types:
-    dependency: "direct main"
-    description:
-      path: "../../packages/komodo_defi_types"
       relative: true
     source: path
     version: "0.3.0+0"

--- a/products/dex_dungeon/pubspec.yaml
+++ b/products/dex_dungeon/pubspec.yaml
@@ -18,12 +18,7 @@ dependencies:
   flutter_bloc: ^9.1.1
   flutter_localizations:
     sdk: flutter
-  google_fonts: ^6.2.1
   intl: ^0.20.2
-  komodo_defi_sdk:
-    path: ../../packages/komodo_defi_sdk
-  komodo_defi_types:
-    path: ../../packages/komodo_defi_types
 
 dev_dependencies:
   bloc_test: ^10.0.0


### PR DESCRIPTION
Remove `google_fonts` and Komodo SDK dependencies from `dex_dungeon` to enable F-Droid submission.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6fe709f-c6ed-4f7c-9e18-e45578f31194">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6fe709f-c6ed-4f7c-9e18-e45578f31194">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

