### PR TITLE
fix(wasm-ops): fix example app login by improving JS call error handling

### DIFF
--- a/packages/komodo_defi_framework/lib/src/js/js_error_utils.dart
+++ b/packages/komodo_defi_framework/lib/src/js/js_error_utils.dart
@@ -1,0 +1,52 @@
+// Utilities for extracting error codes and messages from dartified JS values.
+
+bool _isFiniteNum(num value) => value.isFinite;
+
+/// Attempts to extract a numeric error code from a dartified JS error/value.
+///
+/// Supported shapes:
+/// - int or num (finite)
+/// - String containing an integer
+/// - Map with `code` or `result` as int/num/stringified-int
+int? extractNumericCodeFromDartError(dynamic value) {
+  if (value is int) return value;
+  if (value is num) return _isFiniteNum(value) ? value.toInt() : null;
+
+  if (value is String) {
+    final parsed = int.tryParse(value);
+    if (parsed != null) return parsed;
+  }
+
+  if (value is Map) {
+    final dynamic code = value['code'] ?? value['result'];
+    if (code is int) return code;
+    if (code is num) return _isFiniteNum(code) ? code.toInt() : null;
+    if (code is String) {
+      final parsed = int.tryParse(code);
+      if (parsed != null) return parsed;
+    }
+  }
+
+  return null;
+}
+
+/// Attempts to extract a human-readable message from a dartified JS error/value.
+///
+/// Supported shapes:
+/// - String
+/// - Map with `message` or `error` as String
+String? extractMessageFromDartError(dynamic value) {
+  if (value is String) return value;
+  if (value is Map) {
+    final dynamic message = value['message'] ?? value['error'];
+    if (message is String && message.isNotEmpty) return message;
+  }
+  return null;
+}
+
+// TODO: generalise to a log/string-based watcher for other KDF errors
+/// Heuristic matcher for common "already running" messages.
+bool messageIndicatesAlreadyRunning(String message) {
+  final lower = message.toLowerCase();
+  return lower.contains('already running') || lower.contains('already_running');
+}

--- a/packages/komodo_defi_framework/lib/src/js/js_error_utils.dart
+++ b/packages/komodo_defi_framework/lib/src/js/js_error_utils.dart
@@ -49,9 +49,14 @@ String? extractMessageFromDartError(dynamic value) {
   return null;
 }
 
+const List<String> _alreadyRunningPatterns = [
+  'already running',
+  'already_running',
+];
+
 // TODO: generalise to a log/string-based watcher for other KDF errors
 /// Heuristic matcher for common "already running" messages.
 bool messageIndicatesAlreadyRunning(String message) {
   final lower = message.toLowerCase();
-  return lower.contains('already running') || lower.contains('already_running');
+  return _alreadyRunningPatterns.any(lower.contains);
 }

--- a/packages/komodo_defi_framework/lib/src/js/js_error_utils.dart
+++ b/packages/komodo_defi_framework/lib/src/js/js_error_utils.dart
@@ -1,4 +1,9 @@
-// Utilities for extracting error codes and messages from dartified JS values.
+/// Utilities for extracting error codes and messages from dartified JS values.
+///
+/// Provides functions to extract numeric error codes and human-readable messages
+/// from dartified JavaScript error objects, as well as heuristics for common
+/// error patterns.
+library;
 
 bool _isFiniteNum(num value) => value.isFinite;
 

--- a/packages/komodo_defi_framework/lib/src/js/js_interop_utils.dart
+++ b/packages/komodo_defi_framework/lib/src/js/js_interop_utils.dart
@@ -111,10 +111,21 @@ Future<T> parseJsInteropMaybePromise<T>(
     }
   }
   if (T == double || T == num) {
-    if (dartValue is num) return dartValue as T;
+    if (dartValue is num) {
+      if (T == double) return dartValue.toDouble() as T;
+      return dartValue as T; // T == num
+    }
     if (dartValue is String) {
       final parsed = double.tryParse(dartValue);
-      if (parsed != null) return (T == num ? parsed : parsed) as T;
+      if (parsed != null) {
+        if (T == num) {
+          final num n = parsed;
+          return n as T;
+        } else {
+          final double d = parsed;
+          return d as T;
+        }
+      }
     }
   }
   if (T == String) {

--- a/packages/komodo_defi_framework/lib/src/js/js_interop_utils.dart
+++ b/packages/komodo_defi_framework/lib/src/js/js_interop_utils.dart
@@ -1,0 +1,135 @@
+// ignore_for_file: avoid_dynamic_calls
+
+import 'dart:convert';
+import 'dart:js_interop' as js_interop;
+
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:logging/logging.dart';
+
+final Logger _jsInteropLogger = Logger('JsInteropUtils');
+
+/// Parses a JS interop response into a JsonMap.
+///
+/// Accepts:
+/// - JSAny/JSObject (will be dartified)
+/// - Map (with non-string keys will be normalized)
+/// - String (JSON encoded)
+///
+/// Throws a [FormatException] if the response cannot be parsed into a JSON map.
+JsonMap parseJsInteropJson(dynamic jsResponse) {
+  try {
+    dynamic value = jsResponse;
+
+    // If we received a JS value, convert to Dart first
+    if (value is js_interop.JSAny?) {
+      value = value?.dartify();
+    }
+
+    if (value is String) {
+      final decoded = jsonDecode(value);
+      if (decoded is Map) {
+        return _deepConvertMap(decoded);
+      }
+      throw const FormatException('Expected JSON object string');
+    }
+
+    if (value is Map) {
+      return _deepConvertMap(value);
+    }
+
+    throw FormatException('Unexpected JS response type: ${value.runtimeType}');
+  } catch (e, s) {
+    _jsInteropLogger.severe('Error parsing JS interop response', e, s);
+    rethrow;
+  }
+}
+
+/// Generic helper that parses a JS response and maps it to a Dart model.
+T parseJsInteropCall<T>(dynamic jsResponse, T Function(JsonMap) fromJson) {
+  final map = parseJsInteropJson(jsResponse);
+  return fromJson(map);
+}
+
+// Recursively converts the provided map to JsonMap by stringifying keys and
+// converting nested maps/lists to JSON-friendly structures.
+JsonMap _deepConvertMap(Map<dynamic, dynamic> map) {
+  return map.map((key, value) {
+    if (value is Map) return MapEntry(key.toString(), _deepConvertMap(value));
+    if (value is List) {
+      return MapEntry(key.toString(), _deepConvertList(value));
+    }
+    return MapEntry(key.toString(), value);
+  });
+}
+
+List<dynamic> _deepConvertList(List<dynamic> list) {
+  return list.map((value) {
+    if (value is Map) return _deepConvertMap(value);
+    if (value is List) return _deepConvertList(value);
+    return value;
+  }).toList();
+}
+
+/// Resolves a JS interop value that might be a Promise into a Dart value.
+///
+/// - If [jsValue] is a JSPromise, it awaits the promise, then dartifies it
+/// - If [jsValue] is not a JSPromise, it is dartified directly
+/// - Returns the dartified dynamic value
+Future<dynamic> resolveJsAnyMaybePromise(js_interop.JSAny? jsValue) async {
+  if (jsValue is js_interop.JSPromise) {
+    final resolved = await jsValue.toDart;
+    return resolved?.dartify();
+  }
+  return jsValue?.dartify();
+}
+
+/// Generic helper to resolve a JS interop value (maybe a Promise) and map it.
+///
+/// After resolution and dartification, the provided [mapper] is used to convert
+/// the dynamic result into type [T].
+Future<T> parseJsInteropMaybePromise<T>(
+  js_interop.JSAny? jsValue, [
+  T Function(dynamic dartValue)? mapper,
+]) async {
+  final dartValue = await resolveJsAnyMaybePromise(jsValue);
+
+  // If a mapper was provided, use it
+  if (mapper != null) {
+    return mapper(dartValue);
+  }
+
+  // Allow common primitive/collection types without a mapper
+  if (T == dynamic || T == Object) {
+    return dartValue as T;
+  }
+  if (T == int) {
+    if (dartValue is int) return dartValue as T;
+    if (dartValue is num) return dartValue.toInt() as T;
+    if (dartValue is String) {
+      final parsed = int.tryParse(dartValue);
+      if (parsed != null) return parsed as T;
+    }
+  }
+  if (T == double || T == num) {
+    if (dartValue is num) return dartValue as T;
+    if (dartValue is String) {
+      final parsed = double.tryParse(dartValue);
+      if (parsed != null) return (T == num ? parsed : parsed) as T;
+    }
+  }
+  if (T == String) {
+    if (dartValue is String) return dartValue as T;
+  }
+  if (T == bool) {
+    if (dartValue is bool) return dartValue as T;
+  }
+  if (T == Map || T == Map<String, dynamic>) {
+    if (dartValue is Map) return dartValue as T;
+  }
+  if (T == List || T == List<dynamic>) {
+    if (dartValue is List) return dartValue as T;
+  }
+
+  // Fallback: attempt a direct cast; this will surface a clear type error
+  return dartValue as T;
+}

--- a/packages/komodo_defi_framework/lib/src/js/js_result_mappers.dart
+++ b/packages/komodo_defi_framework/lib/src/js/js_result_mappers.dart
@@ -1,0 +1,46 @@
+import 'package:komodo_defi_framework/src/operations/kdf_operations_interface.dart';
+
+/// Maps the various possible JS return shapes from `mm2_stop` into [StopStatus].
+///
+/// Accepts:
+/// - `null` (treated as OK for backward-compatibility with legacy behavior)
+/// - Numeric codes (int/num)
+/// - String responses like "success", "ok", "already_stopped", or a stringified
+///   integer code
+/// - Objects/Maps that may contain `error`, `result`, or `code` fields
+StopStatus mapJsStopResult(dynamic result) {
+  if (result == null) return StopStatus.ok;
+
+  if (result is int) return StopStatus.fromDefaultInt(result);
+  if (result is num) return StopStatus.fromDefaultInt(result.toInt());
+
+  if (result is String) {
+    final normalized = result.trim().toLowerCase();
+    if (normalized == 'success' || normalized == 'ok') {
+      return StopStatus.ok;
+    }
+    if (normalized == 'already_stopped' || normalized.contains('already')) {
+      return StopStatus.stoppingAlready;
+    }
+    final maybeCode = int.tryParse(result);
+    if (maybeCode != null) return StopStatus.fromDefaultInt(maybeCode);
+    return StopStatus.ok;
+  }
+
+  if (result is Map) {
+    final map = result;
+    if (map.containsKey('error') && map['error'] != null) {
+      return StopStatus.errorStopping;
+    }
+    final inner = map['result'];
+    if (inner is String) return mapJsStopResult(inner);
+    if (inner is num) return StopStatus.fromDefaultInt(inner.toInt());
+
+    final code = map['code'];
+    if (code is num) return StopStatus.fromDefaultInt(code.toInt());
+
+    return StopStatus.ok;
+  }
+
+  return StopStatus.ok;
+}

--- a/packages/komodo_defi_framework/lib/src/js/js_result_mappers.dart
+++ b/packages/komodo_defi_framework/lib/src/js/js_result_mappers.dart
@@ -1,4 +1,7 @@
 import 'package:komodo_defi_framework/src/operations/kdf_operations_interface.dart';
+import 'package:logging/logging.dart';
+
+final _logger = Logger('JsResultMappers');
 
 /// Maps the various possible JS return shapes from `mm2_stop` into [StopStatus].
 ///
@@ -39,8 +42,15 @@ StopStatus mapJsStopResult(dynamic result) {
     final code = map['code'];
     if (code is num) return StopStatus.fromDefaultInt(code.toInt());
 
+    // Log unexpected map structure for debugging
+    _logger.fine(
+      'Unexpected map structure in stop result, defaulting to ok: $map',
+    );
     return StopStatus.ok;
   }
 
+  _logger.fine(
+    'Unrecognized stop result type ${result.runtimeType}, defaulting to ok',
+  );
   return StopStatus.ok;
 }

--- a/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
+++ b/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
@@ -45,6 +45,12 @@ class KdfOperationsWasm implements IKdfOperations {
 
   void _log(String message) => (_logger ?? print).call(message);
 
+  void _debugLog(String message) {
+    if (KdfLoggingConfig.debugLogging) {
+      _log(message);
+    }
+  }
+
   @override
   Future<bool> isAvailable(IKdfHostConfig hostConfig) async {
     try {
@@ -115,18 +121,14 @@ class KdfOperationsWasm implements IKdfOperations {
 
   KdfStartupResult _handleStartupJsError(js_interop.JSAny jsError) {
     try {
-      if (KdfLoggingConfig.debugLogging) {
-        _log('Handling JSAny error: [${jsError.runtimeType}] $jsError');
-      }
+      _debugLog('Handling JSAny error: [${jsError.runtimeType}] $jsError');
 
       // Direct JSNumber error
       if (isInstance<js_interop.JSNumber>(jsError, 'JSNumber')) {
         final dynamic dartNumber = (jsError as js_interop.JSNumber).dartify();
         final code = extractNumericCodeFromDartError(dartNumber);
         if (code != null) {
-          if (KdfLoggingConfig.debugLogging) {
-            _log('KdfOperationsWasm: Resolved as JSNumber code: $code');
-          }
+          _debugLog('KdfOperationsWasm: Resolved as JSNumber code: $code');
           return KdfStartupResult.fromDefaultInt(code);
         }
       }
@@ -155,9 +157,7 @@ class KdfOperationsWasm implements IKdfOperations {
 
       // Try dartify as last resort
       final dynamic error = jsError.dartify();
-      if (KdfLoggingConfig.debugLogging) {
-        _log('Dartified error type: ${error.runtimeType}, value: $error');
-      }
+      _debugLog('Dartified error type: ${error.runtimeType}, value: $error');
 
       final code = extractNumericCodeFromDartError(error);
       if (code != null) return KdfStartupResult.fromDefaultInt(code);
@@ -179,8 +179,7 @@ class KdfOperationsWasm implements IKdfOperations {
     js_interop.JSAny? obj, [
     String? typeString,
   ]) {
-    return obj is T ||
-        obj.instanceOfString(typeString ?? T.runtimeType.toString());
+    return obj.instanceOfString(typeString ?? T.runtimeType.toString());
   }
 
   @override
@@ -238,9 +237,7 @@ class KdfOperationsWasm implements IKdfOperations {
 
   /// Makes the JavaScript RPC call and returns the raw JS response
   Future<js_interop.JSObject> _makeJsCall(JsonMap request) async {
-    if (KdfLoggingConfig.debugLogging) {
-      _log('mm2Rpc request: ${request.censored()}');
-    }
+    _debugLog('mm2Rpc request: ${request.censored()}');
     request['userpass'] = _config.rpcPassword;
 
     final jsRequest = request.jsify() as js_interop.JSObject?;
@@ -277,13 +274,10 @@ class KdfOperationsWasm implements IKdfOperations {
       );
     }
 
-    if (KdfLoggingConfig.debugLogging) {
-      try {
-        final stringified = jsResponse.dartify().toString();
-        _log('Raw JS response: $stringified');
-      } catch (e) {
-        _log('Raw JS response: $jsResponse (stringify failed: $e)');
-      }
+    try {
+      _debugLog('Raw JS response: ${jsResponse.dartify()}');
+    } catch (e) {
+      _debugLog('Raw JS response: $jsResponse (stringify failed: $e)');
     }
     return jsResponse as js_interop.JSObject;
   }
@@ -305,9 +299,7 @@ class KdfOperationsWasm implements IKdfOperations {
       );
     }
 
-    if (KdfLoggingConfig.debugLogging) {
-      _log('JS response validated: $dartResponse');
-    }
+    _debugLog('JS response validated: $dartResponse');
   }
 
   @override

--- a/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
+++ b/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
@@ -7,6 +7,9 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:http/http.dart';
 import 'package:komodo_defi_framework/komodo_defi_framework.dart';
 import 'package:komodo_defi_framework/src/config/kdf_logging_config.dart';
+import 'package:komodo_defi_framework/src/js/js_error_utils.dart';
+import 'package:komodo_defi_framework/src/js/js_interop_utils.dart';
+import 'package:komodo_defi_framework/src/js/js_result_mappers.dart' as js_maps;
 import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
 import 'package:mutex/mutex.dart';
 
@@ -96,66 +99,53 @@ class KdfOperationsWasm implements IKdfOperations {
   Future<KdfStartupResult> _executeKdfMain(
     js_interop.JSObject? jsConfig,
   ) async {
-    final future = _kdfModule!
-        .callMethod(
-          'mm2_main'.toJS,
-          jsConfig,
-          (int level, String message) {
-            _log('[$level] KDF: $message');
-          }.toJS,
-        )
-        .dartify() as Future<dynamic>?;
+    final jsMethod = _kdfModule!.callMethod(
+      'mm2_main'.toJS,
+      jsConfig,
+      (int level, String message) {
+        _log('[$level] KDF: $message');
+      }.toJS,
+    );
 
-    final result = await future;
+    final result = await parseJsInteropMaybePromise<int>(jsMethod);
     _log('mm2_main called: $result');
 
-    if (result is int) {
-      return KdfStartupResult.fromDefaultInt(result);
-    }
-
-    throw Exception(
-      'KDF main returned unexpected type: ${result.runtimeType}',
-    );
+    return KdfStartupResult.fromDefaultInt(result);
   }
 
   KdfStartupResult _handleStartupJsError(js_interop.JSAny jsError) {
     try {
       _log('Handling JSAny error: [${jsError.runtimeType}] $jsError');
 
-      // Try to extract error code from JSNumber
+      // Direct JSNumber error
       if (isInstance<js_interop.JSNumber>(jsError, 'JSNumber')) {
-        final errorCode = (jsError as js_interop.JSNumber).toDartInt;
-        _log('KdfOperationsWasm: Resolved as JSNumber error code: $errorCode');
-        return KdfStartupResult.fromDefaultInt(errorCode);
+        final dynamic dartNumber = (jsError as js_interop.JSNumber).dartify();
+        final code = extractNumericCodeFromDartError(dartNumber);
+        if (code != null) {
+          _log('KdfOperationsWasm: Resolved as JSNumber code: $code');
+          return KdfStartupResult.fromDefaultInt(code);
+        }
       }
 
-      // Try to extract error code from JSObject
+      // JSObject with useful fields
       if (isInstance<js_interop.JSObject>(jsError, 'JSObject')) {
         final jsObj = jsError as js_interop.JSObject;
 
-        // Check for code property
-        if (jsObj.hasProperty('code'.toJS).toDart) {
-          final code = jsObj.getProperty<js_interop.JSNumber?>('code'.toJS);
-          // Check if the property is a JSNumber
-          if (code != null &&
-              isInstance<js_interop.JSNumber>(code, 'JSNumber')) {
-            final errorCode = code.toDartInt;
-            _log(
-              'KdfOperationsWasm: Resolved as JSObject->JSNumber error code: $errorCode',
-            );
-            return KdfStartupResult.fromDefaultInt(errorCode);
-          }
+        // Prefer robust dartify and then inspect
+        final dynamic dartified = jsObj.dartify();
+        final code = extractNumericCodeFromDartError(dartified);
+        if (code != null) return KdfStartupResult.fromDefaultInt(code);
+
+        final msg = extractMessageFromDartError(dartified);
+        if (msg != null && messageIndicatesAlreadyRunning(msg)) {
+          return KdfStartupResult.alreadyRunning;
         }
 
-        // Try toNumber method
-        final asNumber =
-            jsObj.callMethod<js_interop.JSNumber?>('toNumber'.toJS);
-        if (asNumber?.isDefinedAndNotNull ?? false) {
-          final errorCode = asNumber!.toDartInt;
-          _log(
-            'KdfOperationsWasm: Resolved as JSNumber error code: $errorCode',
-          );
-          return KdfStartupResult.fromDefaultInt(errorCode);
+        // Fallback for 'code' property directly on JS object if not covered above
+        if (jsObj.hasProperty('code'.toJS).toDart) {
+          final jsAnyCode = jsObj.getProperty<js_interop.JSAny?>('code'.toJS);
+          final code2 = extractNumericCodeFromDartError(jsAnyCode?.dartify());
+          if (code2 != null) return KdfStartupResult.fromDefaultInt(code2);
         }
       }
 
@@ -163,12 +153,12 @@ class KdfOperationsWasm implements IKdfOperations {
       final dynamic error = jsError.dartify();
       _log('Dartified error type: ${error.runtimeType}, value: $error');
 
-      if (error is int) {
-        return KdfStartupResult.fromDefaultInt(error);
-      } else if (error is num) {
-        return KdfStartupResult.fromDefaultInt(error.toInt());
-      } else if (error is String && int.tryParse(error) != null) {
-        return KdfStartupResult.fromDefaultInt(int.parse(error));
+      final code = extractNumericCodeFromDartError(error);
+      if (code != null) return KdfStartupResult.fromDefaultInt(code);
+
+      final msg = extractMessageFromDartError(error);
+      if (msg != null && messageIndicatesAlreadyRunning(msg)) {
+        return KdfStartupResult.alreadyRunning;
       }
 
       _log('Could not extract error code from JSAny: $error');
@@ -201,35 +191,32 @@ class KdfOperationsWasm implements IKdfOperations {
     await _ensureLoaded();
 
     try {
-      final errorOrNull = await (_kdfModule!
-          .callMethod('mm2_stop'.toJS)
-          .dartify()! as Future<Object?>);
+      // Call mm2_stop which may return a Promise or a direct value
+      final jsAny = _kdfModule!.callMethod<js_interop.JSAny?>('mm2_stop'.toJS);
+      final status =
+          await parseJsInteropMaybePromise(jsAny, js_maps.mapJsStopResult);
 
-      if (errorOrNull is int) {
-        return StopStatus.fromDefaultInt(errorOrNull);
+      // Ensure the node actually stops when we expect success or already stopped
+      if (status == StopStatus.ok || status == StopStatus.stoppingAlready) {
+        await Future.doWhile(() async {
+          final isStopped = (await kdfMainStatus()) == MainStatus.notRunning;
+          if (!isStopped) {
+            await Future<void>.delayed(const Duration(milliseconds: 300));
+          }
+          return !isStopped;
+        }).timeout(
+          const Duration(seconds: 10),
+          onTimeout: () => throw TimeoutException('KDF stop timed out'),
+        );
       }
 
-      _log('KDF stop result: $errorOrNull');
-
-      await Future.doWhile(() async {
-        final isStopped = (await kdfMainStatus()) == MainStatus.notRunning;
-
-        if (!isStopped) {
-          await Future<void>.delayed(const Duration(milliseconds: 300));
-        }
-        return !isStopped;
-      }).timeout(
-        const Duration(seconds: 10),
-        onTimeout: () => throw TimeoutException('KDF stop timed out'),
-      );
+      return status;
     } on int catch (e) {
       return StopStatus.fromDefaultInt(e);
     } catch (e) {
       _log('Error stopping KDF: $e');
       return StopStatus.errorStopping;
     }
-
-    return StopStatus.ok;
   }
 
   @override
@@ -237,7 +224,7 @@ class KdfOperationsWasm implements IKdfOperations {
     await _ensureLoaded();
 
     final jsResponse = await _makeJsCall(request);
-    final dartResponse = _parseDartResponse(jsResponse, request);
+    final dartResponse = parseJsInteropJson(jsResponse);
     _validateResponse(dartResponse, request, jsResponse);
 
     return JsonMap.from(dartResponse);
@@ -295,24 +282,6 @@ class KdfOperationsWasm implements IKdfOperations {
     return jsResponse as js_interop.JSObject;
   }
 
-  /// Converts JS response to Dart Map
-  JsonMap _parseDartResponse(
-    js_interop.JSObject jsResponse,
-    JsonMap request,
-  ) {
-    try {
-      final dynamic converted = jsResponse.dartify();
-      if (converted is! JsonMap) {
-        return _deepConvertMap(converted as Map);
-      }
-      return converted;
-    } catch (e) {
-      _log('Response parsing error for method ${request['method']}:\n'
-          'Request: $request');
-      rethrow;
-    }
-  }
-
   /// Validates the response structure
   void _validateResponse(
     JsonMap dartResponse,
@@ -333,27 +302,6 @@ class KdfOperationsWasm implements IKdfOperations {
     if (KdfLoggingConfig.debugLogging) {
       _log('JS response validated: $dartResponse');
     }
-  }
-
-  /// Recursively converts the provided map to JsonMap. This is required, as
-  /// many of the responses received from the sdk are
-  /// LinkedHashMap<Object?, Object?>
-  Map<String, dynamic> _deepConvertMap(Map<dynamic, dynamic> map) {
-    return map.map((key, value) {
-      if (value is Map) return MapEntry(key.toString(), _deepConvertMap(value));
-      if (value is List) {
-        return MapEntry(key.toString(), _deepConvertList(value));
-      }
-      return MapEntry(key.toString(), value);
-    });
-  }
-
-  List<dynamic> _deepConvertList(List<dynamic> list) {
-    return list.map((value) {
-      if (value is Map) return _deepConvertMap(value);
-      if (value is List) return _deepConvertList(value);
-      return value;
-    }).toList();
   }
 
   @override

--- a/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
+++ b/packages/komodo_defi_framework/lib/src/operations/kdf_operations_wasm.dart
@@ -115,14 +115,18 @@ class KdfOperationsWasm implements IKdfOperations {
 
   KdfStartupResult _handleStartupJsError(js_interop.JSAny jsError) {
     try {
-      _log('Handling JSAny error: [${jsError.runtimeType}] $jsError');
+      if (KdfLoggingConfig.debugLogging) {
+        _log('Handling JSAny error: [${jsError.runtimeType}] $jsError');
+      }
 
       // Direct JSNumber error
       if (isInstance<js_interop.JSNumber>(jsError, 'JSNumber')) {
         final dynamic dartNumber = (jsError as js_interop.JSNumber).dartify();
         final code = extractNumericCodeFromDartError(dartNumber);
         if (code != null) {
-          _log('KdfOperationsWasm: Resolved as JSNumber code: $code');
+          if (KdfLoggingConfig.debugLogging) {
+            _log('KdfOperationsWasm: Resolved as JSNumber code: $code');
+          }
           return KdfStartupResult.fromDefaultInt(code);
         }
       }
@@ -151,7 +155,9 @@ class KdfOperationsWasm implements IKdfOperations {
 
       // Try dartify as last resort
       final dynamic error = jsError.dartify();
-      _log('Dartified error type: ${error.runtimeType}, value: $error');
+      if (KdfLoggingConfig.debugLogging) {
+        _log('Dartified error type: ${error.runtimeType}, value: $error');
+      }
 
       final code = extractNumericCodeFromDartError(error);
       if (code != null) return KdfStartupResult.fromDefaultInt(code);

--- a/packages/komodo_defi_framework/test/js/js_result_mappers_test.dart
+++ b/packages/komodo_defi_framework/test/js/js_result_mappers_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:komodo_defi_framework/src/js/js_result_mappers.dart';
+import 'package:komodo_defi_framework/src/operations/kdf_operations_interface.dart';
+
+void main() {
+  group('mapJsStopResult', () {
+    test('numeric codes', () {
+      expect(mapJsStopResult(0), StopStatus.ok);
+      expect(mapJsStopResult(1), StopStatus.notRunning);
+      expect(mapJsStopResult(2), StopStatus.errorStopping);
+      expect(mapJsStopResult(3), StopStatus.stoppingAlready);
+      expect(mapJsStopResult(3.0), StopStatus.stoppingAlready);
+    });
+
+    test('string responses', () {
+      expect(mapJsStopResult('success'), StopStatus.ok);
+      expect(mapJsStopResult('ok'), StopStatus.ok);
+      expect(mapJsStopResult('already_stopped'), StopStatus.stoppingAlready);
+      expect(mapJsStopResult('Already stopped'), StopStatus.stoppingAlready);
+      expect(mapJsStopResult('2'), StopStatus.errorStopping);
+      expect(mapJsStopResult('unexpected'), StopStatus.ok);
+    });
+
+    test('map responses', () {
+      expect(mapJsStopResult({'error': 'Something'}), StopStatus.errorStopping);
+      expect(mapJsStopResult({'result': 'success'}), StopStatus.ok);
+      expect(mapJsStopResult({'result': 0}), StopStatus.ok);
+      expect(mapJsStopResult({'code': 3}), StopStatus.stoppingAlready);
+      expect(mapJsStopResult({'unexpected': true}), StopStatus.ok);
+    });
+
+    test('null treated as ok', () {
+      expect(mapJsStopResult(null), StopStatus.ok);
+    });
+  });
+}

--- a/packages/komodo_defi_types/lib/src/utils/json_type_utils.dart
+++ b/packages/komodo_defi_types/lib/src/utils/json_type_utils.dart
@@ -120,8 +120,9 @@ T? _traverseJson<T>(
           return jsonFromString(value) as T;
         } catch (e) {
           throw ArgumentError(
-              'Expected a JSON string to parse, but got an invalid type: '
-              '${value.runtimeType}');
+            'Expected a JSON string to parse, but got an invalid type: '
+            '${value.runtimeType}',
+          );
         }
       }
 
@@ -129,7 +130,7 @@ T? _traverseJson<T>(
         return jsonToString(value) as T;
       }
 
-// In the list handling section:
+      // In the list handling section:
       if (T == JsonList && value is String) {
         try {
           return jsonListFromString(value) as T;
@@ -152,6 +153,14 @@ T? _traverseJson<T>(
       // Cast 0 to false and 1 to true for boolean types
       if (T == bool && value is int && (value == 0 || value == 1)) {
         return (value == 1) as T;
+      }
+
+      // Normalize numeric types between int/double for WASM interop
+      if (T == int && value is num) {
+        return value.toInt() as T;
+      }
+      if (T == double && value is num) {
+        return value.toDouble() as T;
       }
 
       // Final type check
@@ -214,9 +223,7 @@ T _convertMap<T>(Map<dynamic, dynamic> sourceMap) {
   try {
     return sanitizedMap as T;
   } catch (e) {
-    throw ArgumentError(
-      'Failed to convert map to expected type $T: $e',
-    );
+    throw ArgumentError('Failed to convert map to expected type $T: $e');
   }
 }
 
@@ -373,9 +380,7 @@ extension MapCensoring<K, V> on Map<K, V> {
     }
 
     final censoredMap = <K, V>{};
-    final stack = <_CensorTask<K, V>>[
-      _CensorTask(targetMap, censoredMap),
-    ];
+    final stack = <_CensorTask<K, V>>[_CensorTask(targetMap, censoredMap)];
 
     while (stack.isNotEmpty) {
       final currentTask = stack.removeLast();

--- a/packages/komodo_defi_types/lib/src/utils/json_type_utils.dart
+++ b/packages/komodo_defi_types/lib/src/utils/json_type_utils.dart
@@ -120,8 +120,8 @@ T? _traverseJson<T>(
           return jsonFromString(value) as T;
         } catch (e) {
           throw ArgumentError(
-            'Expected a JSON string to parse, but got an invalid type: '
-            '${value.runtimeType}',
+            'Failed to parse string as JsonMap. Expected valid JSON string, '
+            'but parsing failed for value of type: ${value.runtimeType}',
           );
         }
       }
@@ -136,8 +136,8 @@ T? _traverseJson<T>(
           return jsonListFromString(value) as T;
         } catch (e) {
           throw ArgumentError(
-            'Expected a JSON string representing a List, '
-            'but got an invalid type: ${value.runtimeType}',
+            'Failed to parse string as JsonList. Expected valid JSON array string, '
+            'but parsing failed for value of type: ${value.runtimeType}',
           );
         }
       }


### PR DESCRIPTION
Fixes the login error when running the example app via Wasm compilation (`flutter run -d chrome --wasm`) by improving JS call error handling and type checking.

Komodo wallet did not suffer the same issue, likely because it configures auth listeners after successful login (in `AuthBloc`)

## Before (current `dev`)

https://github.com/user-attachments/assets/3f2afbf2-cb0e-42a4-986e-9fbe1d049b55

<details>
<summary>Console log snippet</summary>

```text
main.dart.mjs:59 Stopping KDF...
main.dart.mjs:59 Error stopping KDF: Type 'JSValue' is not a subtype of type 'Future<Object?>' in type cast
main.dart.mjs:59 KDF stop result: StopStatus.errorStopping
main.dart.mjs:59 [3] KDF: 12 11:56:24, mm2_core::mm_ctx:603] INFO MmCtx (2384139199) has been dropped
main.dart.mjs:59 [3] KDF: 12 11:56:24, mm2_db::indexed_db::db_driver:94] INFO 'MAIN::KOMODEFI::wallets' database has been closed
main.dart.mjs:59 Couldn't get KDF version: Exception: Unknown error for method version: 1
Request: {userpass: eZrd4OB1cIC0JSVk225CiUGid90afp@1, method: version}
main.dart.mjs:59 KDF is not running.
main.dart.mjs:59 Starting KDF main...
main.dart.mjs:59 Unknown error starting KDF: [_TypeError] Type 'JSValue' is not a subtype of type 'Future<dynamic>?' in type cast
main.dart.mjs:59 KDF main result: KdfStartupResult.invalidParams
main.dart.mjs:59 [3] KDF: 12 11:56:24, mm2_main::lp_native_dex:435] INFO Version: 2.5.1-beta_6172ba8 DT 2025-08-05T18:24:17.373329738+00:00
main.dart.mjs:59 Couldn't get KDF version: Exception: Unknown error for method version: 1
Request: {userpass: eZrd4OB1cIC0JSVk225CiUGid90afp@1, method: version}
main.dart.mjs:59 KDF is not running.
main.dart.mjs:59 Starting KDF main...
main.dart.mjs:59 Unknown error starting KDF: [_TypeError] Type 'JSValue' is not a subtype of type 'Future<dynamic>?' in type cast
main.dart.mjs:59 KDF main result: KdfStartupResult.invalidParams
main.dart.mjs:59 KDF main status: MainStatus.noRpc
kdflib.js:990 mm2_wasm_lib:119] MM2 is already running
imports.wbg.__wbg_error_524f506f44df1645 @ kdflib.js:990
$func26506 @ kdflib_bg.wasm:0x1c53d9c
$func917 @ kdflib_bg.wasm:0x949ca8
$func9903 @ kdflib_bg.wasm:0x18623ce
$__wbindgen_export_8 @ kdflib_bg.wasm:0x1c2b947
__wbg_adapter_53 @ kdflib.js:494
real @ kdflib.js:163
setTimeout
_1449 @ main.dart.mjs:559
$_JSEventLoop._setTimeout @ main.dart.wasm:0x1a7311
$_OneShotTimer._schedule @ timer_patch.dart:128
$new _Timer (constructor body) @ timer_patch.dart:115
$new _OneShotTimer (constructor body) @ timer_patch.dart:124
$_OneShotTimer @ timer_patch.dart:124
$Timer._createTimer @ timer_patch.dart:88
$_RootZone.createTimer @ zone.dart:1873
$new Timer @ timer.dart:46
$new Future.delayed @ future.dart:413
$KomodoDefiFramework.kdfStop inner @ komodo_defi_framework.dart:130
$_awaitHelper closure at org-dartlang-sdk:///dart-sdk/lib/_internal/wasm/lib/async_patch.dart:104:5 @ async_patch.dart:105
$closure wrapper at org-dartlang-sdk:///dart-sdk/lib/_internal/wasm/lib/async_patch.dart:104:5 trampoline @ main.dart.wasm:0x183d45
$_RootZone.runUnary @ zone.dart:1849
$_FutureListener.handleValue (body) @ future_impl.dart:224
$_FutureListener.handleValue (checked entry) @ future_impl.dart:223
$_Future._propagateToListeners closure handleValueCallback at org-dartlang-sdk:///dart-sdk/lib/async/future_impl.dart:949:33 @ future_impl.dart:951
$_Future._propagateToListeners @ future_impl.dart:980
$_Future._completeWithValue (body) @ future_impl.dart:723
$_Future._completeWithValue (unchecked entry) @ future_impl.dart:718
$_Future._asyncCompleteWithValue closure at org-dartlang-sdk:///dart-sdk/lib/async/future_impl.dart:806:29 @ future_impl.dart:807
$closure wrapper at org-dartlang-sdk:///dart-sdk/lib/async/future_impl.dart:806:29 trampoline @ main.dart.wasm:0x18127a
$_microtaskLoop @ schedule_microtask.dart:40
$_startMicrotaskLoop @ schedule_microtask.dart:49
$_startMicrotaskLoop tear-off trampoline @ main.dart.wasm:0x1815c8
$_invokeCallback @ timer_patch.dart:71
(anonymous) @ main.dart.mjs:565
main.dart.mjs:59 [3] KDF: 12 11:56:24, mm2_db::indexed_db::db_driver::builder:72] INFO Open 'MAIN::KOMODEFI::wallets' database with tables: {"mnemonics"}
kdflib.js:865 Uncaught (in promise) StartupError {__wbg_ptr: 5246424}
(anonymous) @ kdflib.js:865
handleError @ kdflib.js:105
imports.wbg.__wbg_call_7cccdd69e0791ae2 @ kdflib.js:864
$func21775 @ kdflib_bg.wasm:0x1b7c1ea
$func917 @ kdflib_bg.wasm:0x94a913
$func9903 @ kdflib_bg.wasm:0x18623ce
$__wbindgen_export_8 @ kdflib_bg.wasm:0x1c2b947
__wbg_adapter_53 @ kdflib.js:494
real @ kdflib.js:163
setTimeout
_1449 @ main.dart.mjs:559
$_JSEventLoop._setTimeout @ main.dart.wasm:0x1a7311
$_OneShotTimer._schedule @ timer_patch.dart:128
$new _Timer (constructor body) @ timer_patch.dart:115
$new _OneShotTimer (constructor body) @ timer_patch.dart:124
$_OneShotTimer @ timer_patch.dart:124
$Timer._createTimer @ timer_patch.dart:88
$_RootZone.createTimer @ zone.dart:1873
$new Timer @ timer.dart:46
$new Future.delayed @ future.dart:413
$KomodoDefiFramework.kdfStop inner @ komodo_defi_framework.dart:130
$_awaitHelper closure at org-dartlang-sdk:///dart-sdk/lib/_internal/wasm/lib/async_patch.dart:104:5 @ async_patch.dart:105
$closure wrapper at org-dartlang-sdk:///dart-sdk/lib/_internal/wasm/lib/async_patch.dart:104:5 trampoline @ main.dart.wasm:0x183d45
$_RootZone.runUnary @ zone.dart:1849
$_FutureListener.handleValue (body) @ future_impl.dart:224
$_FutureListener.handleValue (checked entry) @ future_impl.dart:223
$_Future._propagateToListeners closure handleValueCallback at org-dartlang-sdk:///dart-sdk/lib/async/future_impl.dart:949:33 @ future_impl.dart:951
$_Future._propagateToListeners @ future_impl.dart:980
$_Future._completeWithValue (body) @ future_impl.dart:723
$_Future._completeWithValue (unchecked entry) @ future_impl.dart:718
$_Future._asyncCompleteWithValue closure at org-dartlang-sdk:///dart-sdk/lib/async/future_impl.dart:806:29 @ future_impl.dart:807
$closure wrapper at org-dartlang-sdk:///dart-sdk/lib/async/future_impl.dart:806:29 trampoline @ main.dart.wasm:0x18127a
$_microtaskLoop @ schedule_microtask.dart:40
$_startMicrotaskLoop @ schedule_microtask.dart:49
$_startMicrotaskLoop tear-off trampoline @ main.dart.wasm:0x1815c8
$_invokeCallback @ timer_patch.dart:71
(anonymous) @ main.dart.mjs:565
main.dart.mjs:59 KDF main status: MainStatus.noRpc
```

</details>

## After

https://github.com/user-attachments/assets/3622039a-c557-403a-b68c-359a3e906f80

<details>
<summary>Console logs snippet</summary>

```text
main.dart.mjs:59 mm2_main called: 0
main.dart.mjs:59 KDF main result: KdfStartupResult.ok
main.dart.mjs:59 KDF main status: MainStatus.rpcIsUp
main.dart.mjs:59 Starting KDF main...
kdflib.js:990 mm2_wasm_lib:119] MM2 is already running
imports.wbg.__wbg_error_524f506f44df1645 @ kdflib.js:990
main.dart.mjs:59 Handling JSAny error: [JSValue] [object Object]
main.dart.mjs:59 KDF main result: KdfStartupResult.alreadyRunning
main.dart.mjs:59 KDF main status: MainStatus.rpcIsUp
main.dart.mjs:59 Starting KDF main...
kdflib.js:990 mm2_wasm_lib:119] MM2 is already running
imports.wbg.__wbg_error_524f506f44df1645 @ kdflib.js:990
main.dart.mjs:59 Handling JSAny error: [JSValue] [object Object]
main.dart.mjs:59 KDF main result: KdfStartupResult.alreadyRunning
main.dart.mjs:59 KDF main status: MainStatus.rpcIsUp
```

</details>





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More robust JavaScript interop with automatic parsing of responses and promises.
  - Clearer error messages and detection of “already running” states.

- Bug Fixes
  - More accurate stop status mapping across varied response formats.
  - Improved JSON handling and numeric normalization to reduce parsing errors.

- Refactor
  - Centralized interop and error handling; removed legacy parsing paths for consistency and reliability.

- Tests
  - Added unit tests validating stop-result mapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->