### PR TITLE
feat(hd): HD message signing support in SDK

### DIFF
--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/utility/message_signing_rpc_namespace.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods/utility/message_signing_rpc_namespace.dart
@@ -9,9 +9,21 @@ class MessageSigningMethodsNamespace extends BaseRpcMethodNamespace {
   Future<SignMessageResponse> signMessage({
     required String coin,
     required String message,
+    String? derivationPath,
+    int? accountId,
+    String? chain,
+    int? addressId,
   }) {
     return execute(
-      SignMessageRequest(rpcPass: rpcPass ?? '', coin: coin, message: message),
+      SignMessageRequest(
+        rpcPass: rpcPass ?? '',
+        coin: coin,
+        message: message,
+        derivationPath: derivationPath,
+        accountId: accountId,
+        chain: chain,
+        addressId: addressId,
+      ),
     );
   }
 

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods_library.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods_library.dart
@@ -172,9 +172,21 @@ class UtilityMethods extends BaseRpcMethodNamespace {
   Future<SignMessageResponse> signMessage({
     required String coin,
     required String message,
+    String? derivationPath,
+    int? accountId,
+    String? chain,
+    int? addressId,
     String? rpcPass,
   }) => execute(
-    SignMessageRequest(coin: coin, message: message, rpcPass: rpcPass ?? ''),
+    SignMessageRequest(
+      coin: coin,
+      message: message,
+      rpcPass: rpcPass ?? '',
+      derivationPath: derivationPath,
+      accountId: accountId,
+      chain: chain,
+      addressId: addressId,
+    ),
   );
 
   /// Verifies a message signature

--- a/packages/komodo_defi_sdk/example/lib/widgets/asset/asset_header_widget.dart
+++ b/packages/komodo_defi_sdk/example/lib/widgets/asset/asset_header_widget.dart
@@ -185,6 +185,7 @@ class _AssetHeaderWidgetState extends State<AssetHeaderWidget> {
             coin: widget.asset.id.id,
             message: message,
             address: widget.pubkeys!.keys.first.address,
+            derivationPath: widget.pubkeys!.keys.first.derivationPath,
           );
       setState(() => _signedMessage = signature);
     } catch (e) {

--- a/packages/komodo_defi_sdk/lib/src/message_signing/message_signing_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/message_signing/message_signing_manager.dart
@@ -17,9 +17,9 @@ class MessageSigningManager {
   /// This method creates a cryptographic signature that can be used to prove
   /// ownership of an address.
   ///
-  /// The `address` parameter is not used in the signing process and will be
-  /// ignored. This is in preparation for the near future when KDF will add HD
-  /// wallet support.
+  /// For HD wallets, you can optionally pass a specific derivation to sign
+  /// from using either a full `derivationPath` (preferred) or the
+  /// `accountId`/`chain`/`addressId` components.
   ///
   /// Parameters:
   /// - [coin]: The ticker of the coin to use for signing (e.g., "BTC").
@@ -39,10 +39,18 @@ class MessageSigningManager {
     required String coin,
     required String message,
     required String address,
+    String? derivationPath,
+    int? accountId,
+    String? chain,
+    int? addressId,
   }) async {
     final response = await _client.rpc.utility.signMessage(
       coin: coin,
       message: message,
+      derivationPath: derivationPath,
+      accountId: accountId,
+      chain: chain,
+      addressId: addressId,
     );
     return response.signature;
   }


### PR DESCRIPTION
Add full HD message signing support to the SDK by allowing derivation path or account/chain/index selection.

---
<a href="https://cursor.com/background-agent?bcId=bc-28eba574-c843-45ca-8911-16b9f9ac3f34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28eba574-c843-45ca-8911-16b9f9ac3f34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

