### PR TITLE
Fix coin activation format inconsistencies

### DIFF
--- a/packages/komodo_defi_rpc_methods/lib/src/common_structures/activation/activation_params/erc20_activation_params.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/common_structures/activation/activation_params/erc20_activation_params.dart
@@ -21,8 +21,11 @@ class Erc20ActivationParams extends ActivationParams {
 
   @override
   JsonMap toRpcParams() => super.toRpcParams().deepMerge({
-    'nodes': nodes.map((e) => e.url).toList(),
+    // Align with KDF API which expects node objects (url/gui_auth), not plain strings
+    'nodes': nodes.map((e) => e.toJson()).toList(),
     'swap_contract_address': swapContractAddress,
     'fallback_swap_contract': fallbackSwapContract,
+    // Ensure priv_key_policy uses the structured JSON object for EVM
+    'priv_key_policy': privKeyPolicy?.toJson(),
   });
 }

--- a/packages/komodo_defi_rpc_methods/lib/src/common_structures/activation/activation_params/zhtlc_activation_params.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/common_structures/activation/activation_params/zhtlc_activation_params.dart
@@ -10,7 +10,7 @@ class ZhtlcActivationParams extends ActivationParams {
     required super.mode,
     super.requiredConfirmations,
     super.requiresNotarization = false,
-    super.privKeyPolicy = PrivateKeyPolicy.contextPrivKey,
+    super.privKeyPolicy = const PrivateKeyPolicy.contextPrivKey(),
     super.minAddressesNumber,
     super.scanPolicy,
     super.gapLimit,

--- a/packages/komodo_defi_sdk/lib/src/activation/protocol_strategies/zhtlc_activation_strategy.dart
+++ b/packages/komodo_defi_sdk/lib/src/activation/protocol_strategies/zhtlc_activation_strategy.dart
@@ -42,8 +42,8 @@ class ZhtlcActivationStrategy extends ProtocolActivationStrategy {
 
     try {
       final protocol = asset.protocol as ZhtlcProtocol;
-      final params = ActivationParams.fromConfigJson(protocol.config)
-          .genericCopyWith(
+      final params = ZhtlcActivationParams.fromConfigJson(protocol.config)
+          .copyWith(
             scanBlocksPerIteration: 200,
             scanIntervalMs: 200,
             zcashParamsPath: protocol.zcashParamsPath,


### PR DESCRIPTION
Correct ZHTLC and ERC20 activation parameter serialization to match KDF API expectations.

Previously, ZHTLC activations failed because they didn't correctly use Light mode parameters and `priv_key_policy` had an incorrect default. ERC20 activations failed due to `nodes` being sent as plain strings instead of objects and `priv_key_policy` not being serialized as a structured JSON object, which the EVM API requires.

---
<a href="https://cursor.com/background-agent?bcId=bc-76e585d6-554c-4429-8a8b-4beaeae070f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-76e585d6-554c-4429-8a8b-4beaeae070f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

