### PR TITLE
fix(auth): store bip39 compatibility regardless of wallet type

### DIFF
--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -1,85 +1,85 @@
 {
-  "api": {
-    "api_commit_hash": "80766b0056062797c3c385b9d1497bb31ac00139",
-    "branch": "dev",
-    "fetch_at_build_enabled": true,
-    "concurrent_downloads_enabled": true,
-    "source_urls": [
-      "https://api.github.com/repos/KomodoPlatform/komodo-defi-framework",
-      "https://sdk.devbuilds.komodo.earth/"
-    ],
-    "platforms": {
-      "web": {
-        "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-wasm|mm2_[a-f0-9]{7,40}-wasm|mm2-[a-f0-9]{7,40}-wasm)\\.zip$",
-        "valid_zip_sha256_checksums": [
-          "e2b5bf4487e042998148325d5d4c72f32b14acd341bab074c438933d7b7a56fd"
+    "api": {
+        "api_commit_hash": "ea91c0de38d525ae6d4bf5b9d5c737eda18b79f0",
+        "branch": "dev",
+        "fetch_at_build_enabled": true,
+        "concurrent_downloads_enabled": true,
+        "source_urls": [
+            "https://api.github.com/repos/KomodoPlatform/komodo-defi-framework",
+            "https://sdk.devbuilds.komodo.earth/"
         ],
-        "path": "web/kdf/bin"
-      },
-      "ios": {
-        "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-ios-aarch64|mm2_[a-f0-9]{7,40}-ios-aarch64|mm2-[a-f0-9]{7,40}-ios-aarch64-CI)\\.zip$",
-        "valid_zip_sha256_checksums": [
-          "e2f9a09a19950ca4a04bbe39f07b70b13c9a23216b27f42ffb0fed21d047b000"
-        ],
-        "path": "ios"
-      },
-      "macos": {
-        "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-mac-arm64|mm2-[a-f0-9]{7,40}-Darwin-Release)\\.zip$",
-        "valid_zip_sha256_checksums": [
-          "dc0f26790eca7b9e0b7eb77ec17c518e2364f9f1c08864922e06d583f3e735bf"
-        ],
-        "path": "macos/bin"
-      },
-      "windows": {
-        "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-win-x86-64|mm2_[a-f0-9]{7,40}-win-x86-64|mm2-[a-f0-9]{7,40}-Win64)\\.zip$",
-        "valid_zip_sha256_checksums": [
-          "d9e223a0261c59356554f6776f04e53e89ce5b24f7b1517655f47e7ed6bb10a6"
-        ],
-        "path": "windows/bin"
-      },
-      "android-armv7": {
-        "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-android-armv7|mm2_[a-f0-9]{7,40}-android-armv7|mm2-[a-f0-9]{7,40}-android-armv7-CI)\\.zip$",
-        "valid_zip_sha256_checksums": [
-          "b758f647b1e322a2c04e765041097ddf65ea603e2200ec66230fbf720848b314"
-        ],
-        "path": "android/app/src/main/cpp/libs/armeabi-v7a"
-      },
-      "android-aarch64": {
-        "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-android-aarch64|mm2_[a-f0-9]{7,40}-android-aarch64|mm2-[a-f0-9]{7,40}-android-aarch64-CI)\\.zip$",
-        "valid_zip_sha256_checksums": [
-          "440eb83207dbc0e67e048185a254af4a08a617a935fef3f199d26ce9aec27198"
-        ],
-        "path": "android/app/src/main/cpp/libs/arm64-v8a"
-      },
-      "linux": {
-        "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-linux-x86-64|mm2_[a-f0-9]{7,40}-linux-x86-64|mm2-[a-f0-9]{7,40}-Linux-Release)\\.zip$",
-        "valid_zip_sha256_checksums": [
-          "69cf929fbcba8f36ba7ab6e1dce37c3d5b15ef86de7e11e3146ee9e80ffb5cf4"
-        ],
-        "path": "linux/bin"
-      }
-    }
-  },
-  "coins": {
-    "fetch_at_build_enabled": true,
-    "update_commit_on_build": true,
-    "bundled_coins_repo_commit": "15e42484e25a7bd4a23bf7de50fdf81e7ec2068d",
-    "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",
-    "coins_repo_content_url": "https://raw.githubusercontent.com/KomodoPlatform/coins",
-    "coins_repo_branch": "master",
-    "runtime_updates_enabled": true,
-    "mapped_files": {
-      "assets/config/coins_config.json": "utils/coins_config_unfiltered.json",
-      "assets/config/coins.json": "coins",
-      "assets/config/seed_nodes.json": "seed-nodes.json"
+        "platforms": {
+            "web": {
+                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-wasm|mm2_[a-f0-9]{7,40}-wasm|mm2-[a-f0-9]{7,40}-wasm)\\.zip$",
+                "valid_zip_sha256_checksums": [
+                    "0aeee96323f6b2616bd7dc7c79f8ef47799cd8c078c980a3678daa4d9368697f"
+                ],
+                "path": "web/kdf/bin"
+            },
+            "ios": {
+                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-ios-aarch64|mm2_[a-f0-9]{7,40}-ios-aarch64|mm2-[a-f0-9]{7,40}-ios-aarch64-CI)\\.zip$",
+                "valid_zip_sha256_checksums": [
+                    "eacf8ce2f0aaf63698108bbf9a32482e9edb56d39bed9b782311966903ea9686"
+                ],
+                "path": "ios"
+            },
+            "macos": {
+                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-mac-arm64|mm2-[a-f0-9]{7,40}-Darwin-Release)\\.zip$",
+                "valid_zip_sha256_checksums": [
+                    "737b72426e382eeb0de9758e568e6812ecf40d1fb701909b53b8d9f120541831"
+                ],
+                "path": "macos/bin"
+            },
+            "windows": {
+                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-win-x86-64|mm2_[a-f0-9]{7,40}-win-x86-64|mm2-[a-f0-9]{7,40}-Win64)\\.zip$",
+                "valid_zip_sha256_checksums": [
+                    "087cfdcc670f2b32034aec4faa7a1fe742ef99369e8fd389b198ae9c3048e335"
+                ],
+                "path": "windows/bin"
+            },
+            "android-armv7": {
+                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-android-armv7|mm2_[a-f0-9]{7,40}-android-armv7|mm2-[a-f0-9]{7,40}-android-armv7-CI)\\.zip$",
+                "valid_zip_sha256_checksums": [
+                    "e649ed47da1a5131e1ff9d0f83fc42fde81f666c9b14d2e81a3f588f7b34b392"
+                ],
+                "path": "android/app/src/main/cpp/libs/armeabi-v7a"
+            },
+            "android-aarch64": {
+                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-android-aarch64|mm2_[a-f0-9]{7,40}-android-aarch64|mm2-[a-f0-9]{7,40}-android-aarch64-CI)\\.zip$",
+                "valid_zip_sha256_checksums": [
+                    "a8fefcac2a6365ada8910aefaa5bfa494b22b88b42b9b57930392ed6c0e0a822"
+                ],
+                "path": "android/app/src/main/cpp/libs/arm64-v8a"
+            },
+            "linux": {
+                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-linux-x86-64|mm2_[a-f0-9]{7,40}-linux-x86-64|mm2-[a-f0-9]{7,40}-Linux-Release)\\.zip$",
+                "valid_zip_sha256_checksums": [
+                    "5aa08b09134e9a22661f39b22862758cd7f13eb6c47ebcd7357e7c91bcd9dcaa"
+                ],
+                "path": "linux/bin"
+            }
+        }
     },
-    "mapped_folders": {
-      "assets/coin_icons/png/": "icons"
-    },
-    "concurrent_downloads_enabled": false,
-    "cdn_branch_mirrors": {
-      "master": "https://komodoplatform.github.io/coins",
-      "main": "https://komodoplatform.github.io/coins"
+    "coins": {
+        "fetch_at_build_enabled": true,
+        "update_commit_on_build": true,
+        "bundled_coins_repo_commit": "15e42484e25a7bd4a23bf7de50fdf81e7ec2068d",
+        "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",
+        "coins_repo_content_url": "https://raw.githubusercontent.com/KomodoPlatform/coins",
+        "coins_repo_branch": "master",
+        "runtime_updates_enabled": true,
+        "mapped_files": {
+            "assets/config/coins_config.json": "utils/coins_config_unfiltered.json",
+            "assets/config/coins.json": "coins",
+            "assets/config/seed_nodes.json": "seed-nodes.json"
+        },
+        "mapped_folders": {
+            "assets/coin_icons/png/": "icons"
+        },
+        "concurrent_downloads_enabled": false,
+        "cdn_branch_mirrors": {
+            "master": "https://komodoplatform.github.io/coins",
+            "main": "https://komodoplatform.github.io/coins"
+        }
     }
-  }
 }

--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -1,85 +1,85 @@
 {
-    "api": {
-        "api_commit_hash": "80766b0056062797c3c385b9d1497bb31ac00139",
-        "branch": "dev",
-        "fetch_at_build_enabled": true,
-        "concurrent_downloads_enabled": true,
-        "source_urls": [
-            "https://api.github.com/repos/KomodoPlatform/komodo-defi-framework",
-            "https://sdk.devbuilds.komodo.earth/"
+  "api": {
+    "api_commit_hash": "80766b0056062797c3c385b9d1497bb31ac00139",
+    "branch": "dev",
+    "fetch_at_build_enabled": true,
+    "concurrent_downloads_enabled": true,
+    "source_urls": [
+      "https://api.github.com/repos/KomodoPlatform/komodo-defi-framework",
+      "https://sdk.devbuilds.komodo.earth/"
+    ],
+    "platforms": {
+      "web": {
+        "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-wasm|mm2_[a-f0-9]{7,40}-wasm|mm2-[a-f0-9]{7,40}-wasm)\\.zip$",
+        "valid_zip_sha256_checksums": [
+          "e2b5bf4487e042998148325d5d4c72f32b14acd341bab074c438933d7b7a56fd"
         ],
-        "platforms": {
-            "web": {
-                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-wasm|mm2_[a-f0-9]{7,40}-wasm|mm2-[a-f0-9]{7,40}-wasm)\\.zip$",
-                "valid_zip_sha256_checksums": [
-                    "e2b5bf4487e042998148325d5d4c72f32b14acd341bab074c438933d7b7a56fd"
-                ],
-                "path": "web/kdf/bin"
-            },
-            "ios": {
-                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-ios-aarch64|mm2_[a-f0-9]{7,40}-ios-aarch64|mm2-[a-f0-9]{7,40}-ios-aarch64-CI)\\.zip$",
-                "valid_zip_sha256_checksums": [
-                    "e2f9a09a19950ca4a04bbe39f07b70b13c9a23216b27f42ffb0fed21d047b000"
-                ],
-                "path": "ios"
-            },
-            "macos": {
-                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-mac-arm64|mm2-[a-f0-9]{7,40}-Darwin-Release)\\.zip$",
-                "valid_zip_sha256_checksums": [
-                    "dc0f26790eca7b9e0b7eb77ec17c518e2364f9f1c08864922e06d583f3e735bf"
-                ],
-                "path": "macos/bin"
-            },
-            "windows": {
-                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-win-x86-64|mm2_[a-f0-9]{7,40}-win-x86-64|mm2-[a-f0-9]{7,40}-Win64)\\.zip$",
-                "valid_zip_sha256_checksums": [
-                    "d9e223a0261c59356554f6776f04e53e89ce5b24f7b1517655f47e7ed6bb10a6"
-                ],
-                "path": "windows/bin"
-            },
-            "android-armv7": {
-                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-android-armv7|mm2_[a-f0-9]{7,40}-android-armv7|mm2-[a-f0-9]{7,40}-android-armv7-CI)\\.zip$",
-                "valid_zip_sha256_checksums": [
-                    "b758f647b1e322a2c04e765041097ddf65ea603e2200ec66230fbf720848b314"
-                ],
-                "path": "android/app/src/main/cpp/libs/armeabi-v7a"
-            },
-            "android-aarch64": {
-                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-android-aarch64|mm2_[a-f0-9]{7,40}-android-aarch64|mm2-[a-f0-9]{7,40}-android-aarch64-CI)\\.zip$",
-                "valid_zip_sha256_checksums": [
-                    "440eb83207dbc0e67e048185a254af4a08a617a935fef3f199d26ce9aec27198"
-                ],
-                "path": "android/app/src/main/cpp/libs/arm64-v8a"
-            },
-            "linux": {
-                "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-linux-x86-64|mm2_[a-f0-9]{7,40}-linux-x86-64|mm2-[a-f0-9]{7,40}-Linux-Release)\\.zip$",
-                "valid_zip_sha256_checksums": [
-                    "69cf929fbcba8f36ba7ab6e1dce37c3d5b15ef86de7e11e3146ee9e80ffb5cf4"
-                ],
-                "path": "linux/bin"
-            }
-        }
-    },
-    "coins": {
-        "fetch_at_build_enabled": true,
-        "update_commit_on_build": true,
-        "bundled_coins_repo_commit": "4dfaadc41c499cfbca630a93fa85e7e054005089",
-        "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",
-        "coins_repo_content_url": "https://raw.githubusercontent.com/KomodoPlatform/coins",
-        "coins_repo_branch": "master",
-        "runtime_updates_enabled": true,
-        "mapped_files": {
-            "assets/config/coins_config.json": "utils/coins_config_unfiltered.json",
-            "assets/config/coins.json": "coins",
-            "assets/config/seed_nodes.json": "seed-nodes.json"
-        },
-        "mapped_folders": {
-            "assets/coin_icons/png/": "icons"
-        },
-        "concurrent_downloads_enabled": false,
-        "cdn_branch_mirrors": {
-            "master": "https://komodoplatform.github.io/coins",
-            "main": "https://komodoplatform.github.io/coins"
-        }
+        "path": "web/kdf/bin"
+      },
+      "ios": {
+        "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-ios-aarch64|mm2_[a-f0-9]{7,40}-ios-aarch64|mm2-[a-f0-9]{7,40}-ios-aarch64-CI)\\.zip$",
+        "valid_zip_sha256_checksums": [
+          "e2f9a09a19950ca4a04bbe39f07b70b13c9a23216b27f42ffb0fed21d047b000"
+        ],
+        "path": "ios"
+      },
+      "macos": {
+        "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-mac-arm64|mm2-[a-f0-9]{7,40}-Darwin-Release)\\.zip$",
+        "valid_zip_sha256_checksums": [
+          "dc0f26790eca7b9e0b7eb77ec17c518e2364f9f1c08864922e06d583f3e735bf"
+        ],
+        "path": "macos/bin"
+      },
+      "windows": {
+        "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-win-x86-64|mm2_[a-f0-9]{7,40}-win-x86-64|mm2-[a-f0-9]{7,40}-Win64)\\.zip$",
+        "valid_zip_sha256_checksums": [
+          "d9e223a0261c59356554f6776f04e53e89ce5b24f7b1517655f47e7ed6bb10a6"
+        ],
+        "path": "windows/bin"
+      },
+      "android-armv7": {
+        "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-android-armv7|mm2_[a-f0-9]{7,40}-android-armv7|mm2-[a-f0-9]{7,40}-android-armv7-CI)\\.zip$",
+        "valid_zip_sha256_checksums": [
+          "b758f647b1e322a2c04e765041097ddf65ea603e2200ec66230fbf720848b314"
+        ],
+        "path": "android/app/src/main/cpp/libs/armeabi-v7a"
+      },
+      "android-aarch64": {
+        "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-android-aarch64|mm2_[a-f0-9]{7,40}-android-aarch64|mm2-[a-f0-9]{7,40}-android-aarch64-CI)\\.zip$",
+        "valid_zip_sha256_checksums": [
+          "440eb83207dbc0e67e048185a254af4a08a617a935fef3f199d26ce9aec27198"
+        ],
+        "path": "android/app/src/main/cpp/libs/arm64-v8a"
+      },
+      "linux": {
+        "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-linux-x86-64|mm2_[a-f0-9]{7,40}-linux-x86-64|mm2-[a-f0-9]{7,40}-Linux-Release)\\.zip$",
+        "valid_zip_sha256_checksums": [
+          "69cf929fbcba8f36ba7ab6e1dce37c3d5b15ef86de7e11e3146ee9e80ffb5cf4"
+        ],
+        "path": "linux/bin"
+      }
     }
+  },
+  "coins": {
+    "fetch_at_build_enabled": true,
+    "update_commit_on_build": true,
+    "bundled_coins_repo_commit": "15e42484e25a7bd4a23bf7de50fdf81e7ec2068d",
+    "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",
+    "coins_repo_content_url": "https://raw.githubusercontent.com/KomodoPlatform/coins",
+    "coins_repo_branch": "master",
+    "runtime_updates_enabled": true,
+    "mapped_files": {
+      "assets/config/coins_config.json": "utils/coins_config_unfiltered.json",
+      "assets/config/coins.json": "coins",
+      "assets/config/seed_nodes.json": "seed-nodes.json"
+    },
+    "mapped_folders": {
+      "assets/coin_icons/png/": "icons"
+    },
+    "concurrent_downloads_enabled": false,
+    "cdn_branch_mirrors": {
+      "master": "https://komodoplatform.github.io/coins",
+      "main": "https://komodoplatform.github.io/coins"
+    }
+  }
 }

--- a/packages/komodo_defi_local_auth/lib/src/auth/auth_service_auth_extension.dart
+++ b/packages/komodo_defi_local_auth/lib/src/auth/auth_service_auth_extension.dart
@@ -62,17 +62,10 @@ extension KdfAuthServiceAuthExtension on KdfAuthService {
     // Do not allow authentication to proceed for HD wallets if the seed is not
     // BIP39 compatible.
     if (currentUser.isHd) {
-      try {
-        return await _verifyBip39Compatibility(
-          walletPassword: config.walletPassword,
-          currentUser,
-        );
-      } on AuthException {
-        // Verify BIP39 compatibility for HD wallets after registration
-        // if verification fails, the user can still log into the wallet in legacy
-        // mode.
-        rethrow;
-      }
+      return _verifyBip39Compatibility(
+        currentUser,
+        walletPassword: config.walletPassword,
+      );
     }
 
     return currentUser;
@@ -93,9 +86,9 @@ extension KdfAuthServiceAuthExtension on KdfAuthService {
       );
     }
 
-    final isBip39 = MnemonicValidator().validateBip39(
-      plaintext.plaintextMnemonic!,
-    );
+    final validator = MnemonicValidator();
+    await validator.init();
+    final isBip39 = validator.validateBip39(plaintext.plaintextMnemonic!);
     return isBip39;
   }
 


### PR DESCRIPTION
Fixes the issue with the HD wallet toggle not appearing for legacy migrations and seed file imports. Related to [#3068](https://github.com/KomodoPlatform/komodo-wallet/pull/3068), and it's follow-up [#3126](https://github.com/KomodoPlatform/komodo-wallet/pull/3126).

## Changes 

- Always update `isBip39Seed` regardless of wallet type This previously defaulted to `false` for `iguana` wallets and only updated for HD registrations. 
- Bump the KDF commit hash and checksums to ea91c0d

### Context

The `WalletLogIn` page in komodo-wallet uses the `isBip39Seed` flag to determine whether to show the HD wallet toggle, which would previously remain hidden for legacy wallet migrations, and likely seed file imports as well.

When migrating a legacy wallet or importing a seed file, the user's funds are in the "iguana" derived wallet, so the initial login remains iguana, while allowing for login to the HD wallet if the user wishes (via the HD toggle).

```mermaid
---
title: Previous implementation (with bip39 compatible seed)
---
flowchart LR
    lwl[Legacy Wallet Login]
    lsr[Register SDK wallet with legacy wallet seed]
    lsrc@{ shape: comment, label: "derivationMethod: iguana
    isBip39Seed: false
    show HD toggle: true" }
    
    lwl --> lsr --> lsrc
```

```mermaid
---
title: Current implementation (with bip39 compatible seed)
---
flowchart LR
    lwl[Legacy Wallet Login]
    lsr[Register SDK wallet with legacy wallet seed]
    lsrc@{ shape: comment, label: "derivationMethod: iguana
    isBip39Seed: true
    show HD toggle: true" }
    
    lwl --> lsr --> lsrc
```

## Before

https://github.com/user-attachments/assets/2f8e95ed-c847-46db-8045-6734fd32b599

## After

https://github.com/user-attachments/assets/7a60f2c6-9b33-41d4-954e-5422bbcb8d22


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - HD wallet registration now validates BIP39 seeds immediately, providing clearer errors and preventing setup with invalid mnemonics.

- Chores
  - Updated backend/API version for compatibility.
  - Refreshed platform build checksums to ensure integrity across web, desktop, and mobile.
  - Updated bundled coin definitions to the latest set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->