### PR TITLE
Fix etherscan urls

### DIFF
--- a/packages/komodo_coin_updates/lib/src/coins_config/coin_config_repository.dart
+++ b/packages/komodo_coin_updates/lib/src/coins_config/coin_config_repository.dart
@@ -1,8 +1,5 @@
 import 'package:hive_ce/hive.dart';
-import 'package:komodo_coin_updates/src/coins_config/coin_config_provider.dart';
-import 'package:komodo_coin_updates/src/coins_config/coin_config_storage.dart';
-import 'package:komodo_coin_updates/src/coins_config/config_transform.dart';
-import 'package:komodo_coin_updates/src/coins_config/github_coin_config_provider.dart';
+import 'package:komodo_coin_updates/src/coins_config/_coins_config_index.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:logging/logging.dart';
 
@@ -19,7 +16,8 @@ class CoinConfigRepository implements CoinConfigStorage {
     this.assetsBoxName = 'assets',
     this.settingsBoxName = 'coins_settings',
     this.coinsCommitKey = 'coins_commit',
-  });
+    AssetParser assetParser = const AssetParser(),
+  }) : _assetParser = assetParser;
 
   /// Convenience factory that derives a provider from a runtime config and
   /// uses default Hive boxes (`assets`, `coins_settings`).
@@ -30,11 +28,13 @@ class CoinConfigRepository implements CoinConfigStorage {
     this.assetsBoxName = 'assets',
     this.settingsBoxName = 'coins_settings',
     this.coinsCommitKey = 'coins_commit',
+    AssetParser assetParser = const AssetParser(),
   }) : coinConfigProvider = GithubCoinConfigProvider.fromConfig(
          config,
          githubToken: githubToken,
          transformer: transformer,
-       );
+       ),
+       _assetParser = assetParser;
   static final Logger _log = Logger('CoinConfigRepository');
 
   /// The provider that fetches the coins and coin configs.
@@ -51,6 +51,8 @@ class CoinConfigRepository implements CoinConfigStorage {
 
   /// The key for the coins commit. The value is the commit hash.
   final String coinsCommitKey;
+
+  final AssetParser _assetParser;
 
   /// Fetches the latest commit from the provider, downloads assets for that
   /// commit, and upserts them in local storage along with the commit hash.
@@ -101,6 +103,11 @@ class CoinConfigRepository implements CoinConfigStorage {
   @override
   /// Retrieves all assets from storage, excluding any whose symbol appears
   /// in [excludedAssets]. Returns an empty list if storage is empty.
+  ///
+  /// This method implements a two-pass parsing strategy to rebuild parent-child
+  /// relationships between assets, similar to AssetParser:
+  /// 1. First pass: Parse platform assets (no parent) to get their AssetIds
+  /// 2. Second pass: Reparse child assets using known platform AssetIds
   Future<List<Asset>> getAssets({
     List<String> excludedAssets = const <String>[],
   }) async {
@@ -112,16 +119,25 @@ class CoinConfigRepository implements CoinConfigStorage {
     final values = await Future.wait(
       keys.map((dynamic key) => box.get(key as String)),
     );
-    final result = values
+    final allAssetConfigs = values
         .whereType<Asset>()
         .where((a) => !excludedAssets.contains(a.id.id))
-        .toList();
-    _log.fine('Retrieved ${result.length} assets');
-    return result;
+        .map(
+          (asset) =>
+              MapEntry(asset.id.symbol.assetConfigId, asset.protocol.config),
+        );
+
+    final transformedConfigs = Map<String, Map<String, dynamic>>.fromEntries(
+      allAssetConfigs,
+    );
+    return _assetParser.parseAssetsFromConfig(transformedConfigs);
   }
 
   @override
   /// Retrieves a single [Asset] by its [assetId] from storage.
+  /// NOTE: Parent/child relationships are not rebuilt for single asset retrieval.
+  /// Use [getAssets] if you need proper parent relationships.
+  /// Returns `null` if the asset is not found.
   Future<Asset?> getAsset(AssetId assetId) async {
     _log.fine('Retrieving asset ${assetId.id}');
     final a = await (await _openAssetsBox()).get(assetId.id);

--- a/packages/komodo_coins/lib/src/startup/startup_coins_provider.dart
+++ b/packages/komodo_coins/lib/src/startup/startup_coins_provider.dart
@@ -75,9 +75,15 @@ class StartupCoinsProvider {
       await manager.init();
 
       final assets = manager.all;
-      final configs = <JsonMap>[
-        for (final asset in assets.values) asset.protocol.config,
-      ];
+      // Sort to avoid random ordering of params that causes segfault on linux
+      final configs =
+          <JsonMap>[for (final asset in assets.values) asset.protocol.config]
+            ..sort((a, b) {
+              final aId = a['coin'] as String? ?? '';
+              final bId = b['coin'] as String? ?? '';
+              return aId.compareTo(bId);
+            });
+
       return JsonList.of(configs);
     } finally {
       try {

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods_library.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods_library.dart
@@ -159,35 +159,14 @@ class UtilityMethods extends BaseRpcMethodNamespace {
     required String platform,
     required String contractAddress,
     String? rpcPass,
-  }) async {
-    // Ensure the contract address is mixed-case per API requirements
-    String mixedCaseContract = contractAddress;
-    try {
-      final converted = await execute(
-        ConvertAddressRequest(
-          rpcPass: rpcPass ?? '',
-          coin: platform,
-          fromAddress: contractAddress,
-          toAddressFormat: const AddressFormat(
-            format: 'mixedcase',
-            network: '',
-          ),
-        ),
-      );
-      mixedCaseContract = converted.address;
-    } catch (_) {
-      // Fallback to original if conversion fails
-    }
-
-    return execute(
-      GetTokenInfoRequest(
-        protocolType: protocolType,
-        platform: platform,
-        contractAddress: mixedCaseContract,
-        rpcPass: rpcPass ?? '',
-      ),
-    );
-  }
+  }) => execute(
+    GetTokenInfoRequest(
+      protocolType: protocolType,
+      platform: platform,
+      contractAddress: contractAddress,
+      rpcPass: rpcPass ?? '',
+    ),
+  );
 
   /// Signs a message with a coin's signing key
   Future<SignMessageResponse> signMessage({

--- a/packages/komodo_defi_rpc_methods/lib/src/rpc_methods_library.dart
+++ b/packages/komodo_defi_rpc_methods/lib/src/rpc_methods_library.dart
@@ -159,14 +159,35 @@ class UtilityMethods extends BaseRpcMethodNamespace {
     required String platform,
     required String contractAddress,
     String? rpcPass,
-  }) => execute(
-    GetTokenInfoRequest(
-      protocolType: protocolType,
-      platform: platform,
-      contractAddress: contractAddress,
-      rpcPass: rpcPass ?? '',
-    ),
-  );
+  }) async {
+    // Ensure the contract address is mixed-case per API requirements
+    String mixedCaseContract = contractAddress;
+    try {
+      final converted = await execute(
+        ConvertAddressRequest(
+          rpcPass: rpcPass ?? '',
+          coin: platform,
+          fromAddress: contractAddress,
+          toAddressFormat: const AddressFormat(
+            format: 'mixedcase',
+            network: '',
+          ),
+        ),
+      );
+      mixedCaseContract = converted.address;
+    } catch (_) {
+      // Fallback to original if conversion fails
+    }
+
+    return execute(
+      GetTokenInfoRequest(
+        protocolType: protocolType,
+        platform: platform,
+        contractAddress: mixedCaseContract,
+        rpcPass: rpcPass ?? '',
+      ),
+    );
+  }
 
   /// Signs a message with a coin's signing key
   Future<SignMessageResponse> signMessage({

--- a/packages/komodo_defi_sdk/lib/src/activation/activation_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/activation/activation_manager.dart
@@ -192,23 +192,43 @@ class ActivationManager {
     if (progress.isSuccess) {
       final user = await _auth.currentUser;
       if (user != null) {
-        await _assetHistory.addAssetToWallet(
-          user.walletId,
-          group.primary.id.id,
-        );
-
-        final allAssets = [group.primary, ...(group.children?.toList() ?? [])];
-        for (final asset in allAssets) {
-          if (asset.protocol.isCustomToken) {
-            await _customTokenHistory.addAssetToWallet(user.walletId, asset);
-          }
-          // Pre-cache balance for the activated asset
-          await _balanceManager.precacheBalance(asset);
+        // TODO: consider abstracting this and other custom token operations out
+        // of the activation manager
+        if (group.primary.protocol.isCustomToken) {
+          await _customTokenHistory.addAssetToWallet(
+            user.walletId,
+            group.primary,
+            _assetLookup.available.keys.toSet(),
+          );
+        } else {
+          await _assetHistory.addAssetToWallet(
+            user.walletId,
+            group.primary.id.id,
+          );
         }
 
-        // Notify asset manager to refresh custom tokens if any were activated
+        final allAssets = [group.primary, ...(group.children?.toList() ?? [])];
+
+        // Notify asset lookup before precaching balances to ensure custom token
+        // is available for balance precaching. Shared activation coordinator
+        // somehow allows a recursive activation from PubkeyManager through
+        // resulting in a hanging activation - neither completer completes, and
+        // neither fails.
         if (allAssets.any((asset) => asset.protocol.isCustomToken)) {
           _assetRefreshNotifier.notifyCustomTokensChanged();
+        }
+
+        for (final asset in allAssets) {
+          if (asset.protocol.isCustomToken) {
+            await _customTokenHistory.addAssetToWallet(
+              user.walletId,
+              asset,
+              _assetLookup.available.keys.toSet(),
+            );
+          }
+
+          // Pre-cache balance for the activated asset
+          await _balanceManager.precacheBalance(asset);
         }
       }
 

--- a/packages/komodo_defi_sdk/lib/src/activation/activation_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/activation/activation_manager.dart
@@ -209,13 +209,12 @@ class ActivationManager {
 
         final allAssets = [group.primary, ...(group.children?.toList() ?? [])];
 
-        // Notify asset lookup before precaching balances to ensure custom token
-        // is available for balance precaching. Shared activation coordinator
-        // somehow allows a recursive activation from PubkeyManager through
-        // resulting in a hanging activation - neither completer completes, and
-        // neither fails.
+        // Wait for asset refresh to complete before precaching balances to ensure
+        // custom token is available for balance precaching. This prevents race
+        // conditions where balance precaching fails because the custom token
+        // isn't yet available in the asset lookup.
         if (allAssets.any((asset) => asset.protocol.isCustomToken)) {
-          _assetRefreshNotifier.notifyCustomTokensChanged();
+          await _assetRefreshNotifier.notifyAndWaitForCustomTokensRefresh();
         }
 
         for (final asset in allAssets) {

--- a/packages/komodo_defi_sdk/lib/src/assets/asset_lookup.dart
+++ b/packages/komodo_defi_sdk/lib/src/assets/asset_lookup.dart
@@ -27,8 +27,10 @@ abstract class IAssetProvider extends IAssetLookup {
 }
 
 /// Interface for notifying about asset changes that require UI refresh
-// ignore: one_member_abstracts
 abstract interface class IAssetRefreshNotifier {
   /// Notifies that custom tokens have changed and should be refreshed
   void notifyCustomTokensChanged();
+
+  /// Notifies that custom tokens have changed and waits for refresh to complete
+  Future<void> notifyAndWaitForCustomTokensRefresh();
 }

--- a/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
@@ -142,6 +142,7 @@ class AssetManager implements IAssetProvider, IAssetRefreshNotifier {
 
     final customTokens = await _customAssetHistory.getWalletAssets(
       user.walletId,
+      _orderedCoins.keys.toSet(),
     );
 
     final filteredCustomTokens = _filterCustomTokens(customTokens);

--- a/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
+++ b/packages/komodo_defi_sdk/lib/src/assets/asset_manager.dart
@@ -284,6 +284,16 @@ class AssetManager implements IAssetProvider, IAssetRefreshNotifier {
     );
   }
 
+  @override
+  Future<void> notifyAndWaitForCustomTokensRefresh() async {
+    try {
+      await _refreshCustomTokens();
+    } catch (e) {
+      debugPrint('Custom token refresh failed: $e');
+      rethrow;
+    }
+  }
+
   /// Filters custom tokens based on the current asset filtering strategy.
   ///
   /// Custom tokens don't have traditional coin configs, so we create a minimal

--- a/packages/komodo_defi_sdk/lib/src/transaction_history/strategies/etherscan_transaction_history_strategy.dart
+++ b/packages/komodo_defi_sdk/lib/src/transaction_history/strategies/etherscan_transaction_history_strategy.dart
@@ -252,7 +252,11 @@ class EtherscanProtocolHelper {
     }
 
     final protocol = asset.protocol as Erc20Protocol;
-    return '$baseEndpoint/${protocol.swapContractAddress}';
+    final tokenContractAddress = protocol.contractAddress;
+    if (tokenContractAddress == null || tokenContractAddress.isEmpty) {
+      return null;
+    }
+    return '$baseEndpoint/$tokenContractAddress';
   }
 
   String? _getBaseEndpoint(AssetId id) {

--- a/packages/komodo_defi_sdk/lib/src/transaction_history/strategies/etherscan_transaction_history_strategy.dart
+++ b/packages/komodo_defi_sdk/lib/src/transaction_history/strategies/etherscan_transaction_history_strategy.dart
@@ -1,5 +1,5 @@
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:http/http.dart' as http;
 import 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart';
 import 'package:komodo_defi_sdk/src/pubkeys/pubkey_manager.dart';
@@ -257,9 +257,7 @@ class EtherscanProtocolHelper {
       return null;
     }
 
-    // Token-specific URLs are returning 404, so use ETH URL until resolved
-    // or clarified
-    return '$_ethUrl/$tokenContractAddress';
+    return '$baseEndpoint/$tokenContractAddress';
   }
 
   String? _getBaseEndpoint(AssetId id) {

--- a/packages/komodo_defi_sdk/lib/src/transaction_history/strategies/etherscan_transaction_history_strategy.dart
+++ b/packages/komodo_defi_sdk/lib/src/transaction_history/strategies/etherscan_transaction_history_strategy.dart
@@ -63,8 +63,9 @@ class EtherscanTransactionStrategy extends TransactionHistoryStrategy {
       for (final address in addresses) {
         final uri = url.replace(
           pathSegments: [...url.pathSegments, address.address],
-          queryParameters:
-              asset.protocol.isTestnet ? {'testnet': 'true'} : null,
+          queryParameters: asset.protocol.isTestnet
+              ? {'testnet': 'true'}
+              : null,
         );
         // Add the address as the next path segment
 
@@ -88,14 +89,14 @@ class EtherscanTransactionStrategy extends TransactionHistoryStrategy {
           t.fromId,
           t.itemCount,
         ),
-        _ =>
-          throw UnsupportedError(
-            'Unsupported pagination type: ${pagination.runtimeType}',
-          ),
+        _ => throw UnsupportedError(
+          'Unsupported pagination type: ${pagination.runtimeType}',
+        ),
       };
 
-      final currentBlock =
-          allTransactions.isNotEmpty ? allTransactions.first.blockHeight : 0;
+      final currentBlock = allTransactions.isNotEmpty
+          ? allTransactions.first.blockHeight
+          : 0;
 
       return MyTxHistoryResponse(
         mmrpc: RpcVersion.v2_0,
@@ -152,13 +153,12 @@ class EtherscanTransactionStrategy extends TransactionHistoryStrategy {
             blockHeight: tx.value<int>('block_height'),
             confirmations: tx.value<int>('confirmations'),
             timestamp: tx.value<int>('timestamp'),
-            feeDetails:
-                tx.valueOrNull<JsonMap>('fee_details') != null
-                    ? FeeInfo.fromJson(
-                      tx.value<JsonMap>('fee_details')
-                        ..setIfAbsentOrEmpty('type', 'EthGas'),
-                    )
-                    : null,
+            feeDetails: tx.valueOrNull<JsonMap>('fee_details') != null
+                ? FeeInfo.fromJson(
+                    tx.value<JsonMap>('fee_details')
+                      ..setIfAbsentOrEmpty('type', 'EthGas'),
+                  )
+                : null,
             coin: coinId,
             internalId: tx.value<String>('internal_id'),
             memo: tx.valueOrNull<String>('memo'),
@@ -256,7 +256,10 @@ class EtherscanProtocolHelper {
     if (tokenContractAddress == null || tokenContractAddress.isEmpty) {
       return null;
     }
-    return '$baseEndpoint/$tokenContractAddress';
+
+    // Token-specific URLs are returning 404, so use ETH URL until resolved
+    // or clarified
+    return '$_ethUrl/$tokenContractAddress';
   }
 
   String? _getBaseEndpoint(AssetId id) {


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/komodo-wallet/issues/3098

- Updates url builder for https://etherscan-proxy-v2.komodo.earth/ to use token contract address (not swap contract address).
- Updates `get_token_info` to ensure mixed case contract address and avoid checksum fail errors

To test:
- Add a custom token for PLG20/BEP20/AVX20/ERC20, and use lowercase contract address.
    - Ensure the [correct network](https://github.com/KomodoPlatform/komodo-wallet/issues/3098) is returned. 
    - Ensure non-error response (confirmed address conversion to mixed case)
- Enter PLG20/BEP20/AVX20/ERC20 token wallet page with balance and prior transaction activity. History should be populated (There is some work pending in https://github.com/KomodoPlatform/etherscan-mm2-proxy/ so this may not be ready for a few hours)