### PR TITLE
Add log stream and callback to constructor

### DIFF
--- a/packages/komodo_defi_sdk/lib/src/bootstrap.dart
+++ b/packages/komodo_defi_sdk/lib/src/bootstrap.dart
@@ -24,6 +24,7 @@ Future<void> bootstrap({
   required KomodoDefiSdkConfig config,
   required GetIt container,
   KomodoDefiFramework? kdfFramework,
+  void Function(String)? externalLogger,
 }) async {
   final rpcPassword = await SecureRpcPasswordMixin().ensureRpcPassword();
 
@@ -36,7 +37,7 @@ Future<void> bootstrap({
 
     return KomodoDefiFramework.create(
       hostConfig: resolvedHostConfig,
-      externalLogger: kDebugMode ? print : null,
+      externalLogger: externalLogger ?? (kDebugMode ? print : null),
     );
   });
 

--- a/packages/komodo_defi_sdk/lib/src/komodo_defi_sdk.dart
+++ b/packages/komodo_defi_sdk/lib/src/komodo_defi_sdk.dart
@@ -1,4 +1,5 @@
 import 'dart:developer';
+import 'dart:async';
 
 import 'package:get_it/get_it.dart';
 import 'package:komodo_defi_framework/komodo_defi_framework.dart';
@@ -109,8 +110,17 @@ class KomodoDefiSdk with SecureRpcPasswordMixin {
   ///   )
   /// );
   /// ```
-  factory KomodoDefiSdk({IKdfHostConfig? host, KomodoDefiSdkConfig? config}) {
-    return KomodoDefiSdk._(host, config ?? const KomodoDefiSdkConfig(), null);
+  factory KomodoDefiSdk({
+    IKdfHostConfig? host,
+    KomodoDefiSdkConfig? config,
+    void Function(String)? onLog,
+  }) {
+    return KomodoDefiSdk._(
+      host,
+      config ?? const KomodoDefiSdkConfig(),
+      null,
+      onLog,
+    );
   }
 
   /// Creates a new SDK instance from an existing KDF framework instance.
@@ -126,16 +136,26 @@ class KomodoDefiSdk with SecureRpcPasswordMixin {
   factory KomodoDefiSdk.fromFramework(
     KomodoDefiFramework framework, {
     KomodoDefiSdkConfig? config,
+    void Function(String)? onLog,
   }) {
     return KomodoDefiSdk._(
       null,
       config ?? const KomodoDefiSdkConfig(),
       framework,
+      onLog,
     );
   }
 
-  KomodoDefiSdk._(this._hostConfig, this._config, this._kdfFramework) {
+  KomodoDefiSdk._(
+    this._hostConfig,
+    this._config,
+    this._kdfFramework,
+    this._onLog,
+  ) {
     _container = GetIt.asNewInstance();
+    if (_kdfFramework != null && _onLog != null) {
+      _logSubscription = _kdfFramework!.logStream.listen(_onLog!);
+    }
   }
 
   final IKdfHostConfig? _hostConfig;
@@ -145,6 +165,8 @@ class KomodoDefiSdk with SecureRpcPasswordMixin {
   bool _isInitialized = false;
   bool _isDisposed = false;
   Future<void>? _initializationFuture;
+  final void Function(String)? _onLog;
+  StreamSubscription<String>? _logSubscription;
 
   /// The API client for making direct RPC calls.
   ///
@@ -262,6 +284,14 @@ class KomodoDefiSdk with SecureRpcPasswordMixin {
   BalanceManager get balances =>
       _assertSdkInitialized(_container<BalanceManager>());
 
+  /// Public stream of framework logs.
+  ///
+  /// Subscribe to receive human-readable log messages from the underlying
+  /// Komodo DeFi Framework. Requires the SDK to be initialized.
+  Stream<String> get logStream => _assertSdkInitialized(
+        _container<KomodoDefiFramework>().logStream,
+      );
+
   /// Initializes the SDK instance.
   ///
   /// This must be called before using any SDK functionality. The initialization
@@ -305,6 +335,7 @@ class KomodoDefiSdk with SecureRpcPasswordMixin {
       config: _config,
       kdfFramework: _kdfFramework,
       container: _container,
+      externalLogger: _onLog,
     );
     _isInitialized = true;
   }
@@ -362,6 +393,9 @@ class KomodoDefiSdk with SecureRpcPasswordMixin {
 
     _isInitialized = false;
     _initializationFuture = null;
+
+    await _logSubscription?.cancel();
+    _logSubscription = null;
 
     await Future.wait([
       _disposeIfRegistered<KomodoDefiLocalAuth>((m) => m.dispose()),


### PR DESCRIPTION
Expose `KomodoDefiSdk` log stream and add an optional `onLog` callback to its constructors to allow external log handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-7db52659-a1c7-4561-a34e-f44872fe8889">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7db52659-a1c7-4561-a34e-f44872fe8889">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

