### PR TITLE
fix(binance): use the per-coin supported quote currency list instead of the global cache

### DIFF
--- a/packages/komodo_cex_market_data/lib/src/binance/data/binance_repository.dart
+++ b/packages/komodo_cex_market_data/lib/src/binance/data/binance_repository.dart
@@ -290,12 +290,16 @@ class BinanceRepository implements CexRepository {
       final fiat = fiatCurrency.binanceId;
       // If resolveTradingSymbol throws, treat as unsupported
       final tradingSymbol = resolveTradingSymbol(assetId);
-      final supportsAsset = coins.any(
+
+      // Find the specific coin
+      final coin = coins.firstWhere(
         (c) => c.id.toUpperCase() == tradingSymbol.toUpperCase(),
+        orElse: () => throw ArgumentError('Asset not found'),
       );
-      final supportsFiat =
-          _cachedFiatCurrencies?.contains(fiat.toUpperCase()) ?? false;
-      return supportsAsset && supportsFiat;
+
+      // Check if this specific coin supports the mapped fiat currency
+      final supportsFiat = coin.currencies.contains(fiat.toUpperCase());
+      return supportsFiat;
     } on ArgumentError {
       return false;
     }

--- a/packages/komodo_cex_market_data/lib/src/coingecko/data/coingecko_repository.dart
+++ b/packages/komodo_cex_market_data/lib/src/coingecko/data/coingecko_repository.dart
@@ -2,7 +2,6 @@ import 'package:async/async.dart';
 import 'package:decimal/decimal.dart';
 import 'package:komodo_cex_market_data/src/cex_repository.dart';
 import 'package:komodo_cex_market_data/src/coingecko/_coingecko_index.dart';
-import 'package:komodo_cex_market_data/src/coingecko/models/coin_historical_data/coin_historical_data.dart';
 import 'package:komodo_cex_market_data/src/id_resolution_strategy.dart';
 import 'package:komodo_cex_market_data/src/models/_models_index.dart';
 import 'package:komodo_cex_market_data/src/repository_selection_strategy.dart';

--- a/packages/komodo_cex_market_data/test/binance/binance_repository_test.dart
+++ b/packages/komodo_cex_market_data/test/binance/binance_repository_test.dart
@@ -528,5 +528,712 @@ void main() {
         },
       );
     });
+
+    group('USD stablecoin fallback functionality', () {
+      late BinanceRepository repositoryWithFallbacks;
+      late MockIBinanceProvider mockProviderWithFallbacks;
+
+      setUp(() {
+        mockProviderWithFallbacks = MockIBinanceProvider();
+        repositoryWithFallbacks = BinanceRepository(
+          binanceProvider: mockProviderWithFallbacks,
+          enableMemoization: false,
+        );
+
+        // Mock exchange info with fallback scenarios
+        final mockExchangeInfoWithFallbacks =
+            buildExchangeInfoWithFallbackStablecoins();
+
+        when(
+          () => mockProviderWithFallbacks.fetchExchangeInfoReduced(
+            baseUrl: any(named: 'baseUrl'),
+          ),
+        ).thenAnswer((_) async => mockExchangeInfoWithFallbacks);
+      });
+
+      test('should support USD when coin has BUSD but not USDT', () async {
+        final fallbackAssetId = AssetId(
+          id: 'fallbackcoin',
+          name: 'Fallback Coin',
+          symbol: AssetSymbol(assetConfigId: 'FALLBACK'),
+          chainId: AssetChainId(chainId: 0),
+          derivationPath: null,
+          subClass: CoinSubClass.utxo,
+        );
+
+        final supportsUsd = await repositoryWithFallbacks.supports(
+          fallbackAssetId,
+          FiatCurrency.usd,
+          PriceRequestType.currentPrice,
+        );
+
+        expect(
+          supportsUsd,
+          isTrue,
+          reason: 'FALLBACK should support USD via BUSD fallback',
+        );
+      });
+
+      test('should support USDT when coin has USDC but not USDT', () async {
+        final onlyUsdcAssetId = AssetId(
+          id: 'onlyusdccoin',
+          name: 'Only USDC Coin',
+          symbol: AssetSymbol(assetConfigId: 'ONLYUSDC'),
+          chainId: AssetChainId(chainId: 0),
+          derivationPath: null,
+          subClass: CoinSubClass.utxo,
+        );
+
+        final supportsUsdt = await repositoryWithFallbacks.supports(
+          onlyUsdcAssetId,
+          Stablecoin.usdt,
+          PriceRequestType.currentPrice,
+        );
+
+        expect(
+          supportsUsdt,
+          isTrue,
+          reason: 'ONLYUSDC should support USDT via USDC fallback',
+        );
+      });
+
+      test('should not support USD when coin has no USD stablecoins', () async {
+        final noUsdAssetId = AssetId(
+          id: 'nousdcoin',
+          name: 'No USD Coin',
+          symbol: AssetSymbol(assetConfigId: 'NOUSD'),
+          chainId: AssetChainId(chainId: 0),
+          derivationPath: null,
+          subClass: CoinSubClass.utxo,
+        );
+
+        final supportsUsd = await repositoryWithFallbacks.supports(
+          noUsdAssetId,
+          FiatCurrency.usd,
+          PriceRequestType.currentPrice,
+        );
+
+        expect(
+          supportsUsd,
+          isFalse,
+          reason: 'NOUSD should not support USD as it has no USD stablecoins',
+        );
+      });
+
+      test('should fetch price using BUSD when USDT not available', () async {
+        // Mock OHLC data for FALLBACKBUSD pair
+        final mockOhlc = CoinOhlc(
+          ohlc: [
+            Ohlc.binance(
+              open: Decimal.fromInt(100),
+              high: Decimal.fromInt(105),
+              low: Decimal.fromInt(98),
+              close: Decimal.fromInt(102),
+              openTime: DateTime.now()
+                  .subtract(const Duration(days: 1))
+                  .millisecondsSinceEpoch,
+              closeTime: DateTime.now().millisecondsSinceEpoch,
+            ),
+          ],
+        );
+
+        when(
+          () => mockProviderWithFallbacks.fetchKlines(
+            'FALLBACKBUSD',
+            any(),
+            startUnixTimestampMilliseconds: any(
+              named: 'startUnixTimestampMilliseconds',
+            ),
+            endUnixTimestampMilliseconds: any(
+              named: 'endUnixTimestampMilliseconds',
+            ),
+            limit: any(named: 'limit'),
+            baseUrl: any(named: 'baseUrl'),
+          ),
+        ).thenAnswer((_) async => mockOhlc);
+
+        final fallbackAssetId = AssetId(
+          id: 'fallbackcoin',
+          name: 'Fallback Coin',
+          symbol: AssetSymbol(assetConfigId: 'FALLBACK'),
+          chainId: AssetChainId(chainId: 0),
+          derivationPath: null,
+          subClass: CoinSubClass.utxo,
+        );
+
+        final price = await repositoryWithFallbacks.getCoinFiatPrice(
+          fallbackAssetId,
+          fiatCurrency: FiatCurrency.usd,
+        );
+
+        expect(price, equals(Decimal.fromInt(102)));
+
+        // Verify that BUSD pair was used instead of USDT
+        verify(
+          () => mockProviderWithFallbacks.fetchKlines(
+            'FALLBACKBUSD',
+            any(),
+            startUnixTimestampMilliseconds: any(
+              named: 'startUnixTimestampMilliseconds',
+            ),
+            endUnixTimestampMilliseconds: any(
+              named: 'endUnixTimestampMilliseconds',
+            ),
+            limit: 1,
+            baseUrl: any(named: 'baseUrl'),
+          ),
+        ).called(1);
+      });
+
+      test(
+        'should fetch 24hr price change using USDC when USDT not available',
+        () async {
+          final mockTicker = Binance24hrTicker(
+            symbol: 'ONLYUSDCUSDC',
+            priceChange: Decimal.parse('5.0'),
+            priceChangePercent: Decimal.parse('5.0'),
+            weightedAvgPrice: Decimal.parse('105'),
+            prevClosePrice: Decimal.parse('100'),
+            lastPrice: Decimal.parse('105'),
+            lastQty: Decimal.parse('0.1'),
+            bidPrice: Decimal.parse('104.5'),
+            bidQty: Decimal.parse('0.1'),
+            askPrice: Decimal.parse('105.5'),
+            askQty: Decimal.parse('0.1'),
+            openPrice: Decimal.parse('100'),
+            highPrice: Decimal.parse('106'),
+            lowPrice: Decimal.parse('99'),
+            volume: Decimal.parse('1000'),
+            quoteVolume: Decimal.parse('105000'),
+            openTime: DateTime.now()
+                .subtract(const Duration(hours: 24))
+                .millisecondsSinceEpoch,
+            closeTime: DateTime.now().millisecondsSinceEpoch,
+            firstId: 1,
+            lastId: 10000,
+            count: 10000,
+          );
+
+          when(
+            () => mockProviderWithFallbacks.fetch24hrTicker(
+              'ONLYUSDCUSDC',
+              baseUrl: any(named: 'baseUrl'),
+            ),
+          ).thenAnswer((_) async => mockTicker);
+
+          final onlyUsdcAssetId = AssetId(
+            id: 'onlyusdccoin',
+            name: 'Only USDC Coin',
+            symbol: AssetSymbol(assetConfigId: 'ONLYUSDC'),
+            chainId: AssetChainId(chainId: 0),
+            derivationPath: null,
+            subClass: CoinSubClass.utxo,
+          );
+
+          final priceChange = await repositoryWithFallbacks
+              .getCoin24hrPriceChange(
+                onlyUsdcAssetId,
+                fiatCurrency:
+                    Stablecoin.usdt, // Request USDT but should use USDC
+              );
+
+          expect(priceChange, equals(Decimal.parse('5.0')));
+
+          // Verify that USDC pair was used instead of USDT
+          verify(
+            () => mockProviderWithFallbacks.fetch24hrTicker(
+              'ONLYUSDCUSDC',
+              baseUrl: any(named: 'baseUrl'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'should prefer USDT over other stablecoins when available',
+        () async {
+          final btcAssetId = AssetId(
+            id: 'bitcoin',
+            name: 'Bitcoin',
+            symbol: AssetSymbol(assetConfigId: 'BTC'),
+            chainId: AssetChainId(chainId: 0),
+            derivationPath: null,
+            subClass: CoinSubClass.utxo,
+          );
+
+          // Mock OHLC data for BTCUSDT pair
+          final mockOhlc = CoinOhlc(
+            ohlc: [
+              Ohlc.binance(
+                open: Decimal.fromInt(50000),
+                high: Decimal.fromInt(51000),
+                low: Decimal.fromInt(49000),
+                close: Decimal.fromInt(50500),
+                openTime: DateTime.now()
+                    .subtract(const Duration(days: 1))
+                    .millisecondsSinceEpoch,
+                closeTime: DateTime.now().millisecondsSinceEpoch,
+              ),
+            ],
+          );
+
+          when(
+            () => mockProviderWithFallbacks.fetchKlines(
+              'BTCUSDT',
+              any(),
+              startUnixTimestampMilliseconds: any(
+                named: 'startUnixTimestampMilliseconds',
+              ),
+              endUnixTimestampMilliseconds: any(
+                named: 'endUnixTimestampMilliseconds',
+              ),
+              limit: any(named: 'limit'),
+              baseUrl: any(named: 'baseUrl'),
+            ),
+          ).thenAnswer((_) async => mockOhlc);
+
+          final price = await repositoryWithFallbacks.getCoinFiatPrice(
+            btcAssetId,
+            fiatCurrency: FiatCurrency.usd,
+          );
+
+          expect(price, equals(Decimal.fromInt(50500)));
+
+          // Verify that USDT pair was used (preferred over USDC/BUSD)
+          verify(
+            () => mockProviderWithFallbacks.fetchKlines(
+              'BTCUSDT',
+              any(),
+              startUnixTimestampMilliseconds: any(
+                named: 'startUnixTimestampMilliseconds',
+              ),
+              endUnixTimestampMilliseconds: any(
+                named: 'endUnixTimestampMilliseconds',
+              ),
+              limit: 1,
+              baseUrl: any(named: 'baseUrl'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'should throw error when no suitable USD stablecoin available',
+        () async {
+          final noUsdAssetId = AssetId(
+            id: 'nousdcoin',
+            name: 'No USD Coin',
+            symbol: AssetSymbol(assetConfigId: 'NOUSD'),
+            chainId: AssetChainId(chainId: 0),
+            derivationPath: null,
+            subClass: CoinSubClass.utxo,
+          );
+
+          expect(
+            () async => await repositoryWithFallbacks.getCoinFiatPrice(
+              noUsdAssetId,
+              fiatCurrency: FiatCurrency.usd,
+            ),
+            throwsA(isA<ArgumentError>()),
+            reason:
+                'Should throw error when no USD stablecoins are available for the coin',
+          );
+        },
+      );
+    });
+
+    group('Real-world USD stablecoin priority examples', () {
+      late BinanceRepository realWorldRepository;
+      late MockIBinanceProvider mockRealWorldProvider;
+
+      setUp(() {
+        mockRealWorldProvider = MockIBinanceProvider();
+        realWorldRepository = BinanceRepository(
+          binanceProvider: mockRealWorldProvider,
+          enableMemoization: false,
+        );
+
+        // Mock exchange info with real-world example scenarios
+        final mockRealWorldExchangeInfo = buildRealWorldExampleExchangeInfo();
+
+        when(
+          () => mockRealWorldProvider.fetchExchangeInfoReduced(
+            baseUrl: any(named: 'baseUrl'),
+          ),
+        ).thenAnswer((_) async => mockRealWorldExchangeInfo);
+      });
+
+      test(
+        'BTC should prefer USDT when available (highest priority)',
+        () async {
+          final btcAssetId = AssetId(
+            id: 'bitcoin',
+            name: 'Bitcoin',
+            symbol: AssetSymbol(assetConfigId: 'BTC'),
+            chainId: AssetChainId(chainId: 0),
+            derivationPath: null,
+            subClass: CoinSubClass.utxo,
+          );
+
+          final supportsUsd = await realWorldRepository.supports(
+            btcAssetId,
+            FiatCurrency.usd,
+            PriceRequestType.currentPrice,
+          );
+
+          expect(supportsUsd, isTrue);
+
+          // Mock OHLC for BTCUSDT
+          final mockOhlc = CoinOhlc(
+            ohlc: [
+              Ohlc.binance(
+                open: Decimal.fromInt(50000),
+                high: Decimal.fromInt(51000),
+                low: Decimal.fromInt(49000),
+                close: Decimal.fromInt(50500),
+                openTime: DateTime.now()
+                    .subtract(const Duration(days: 1))
+                    .millisecondsSinceEpoch,
+                closeTime: DateTime.now().millisecondsSinceEpoch,
+              ),
+            ],
+          );
+
+          when(
+            () => mockRealWorldProvider.fetchKlines(
+              'BTCUSDT',
+              any(),
+              startUnixTimestampMilliseconds: any(
+                named: 'startUnixTimestampMilliseconds',
+              ),
+              endUnixTimestampMilliseconds: any(
+                named: 'endUnixTimestampMilliseconds',
+              ),
+              limit: any(named: 'limit'),
+              baseUrl: any(named: 'baseUrl'),
+            ),
+          ).thenAnswer((_) async => mockOhlc);
+
+          final price = await realWorldRepository.getCoinFiatPrice(
+            btcAssetId,
+            fiatCurrency: FiatCurrency.usd,
+          );
+
+          expect(price, equals(Decimal.fromInt(50500)));
+
+          // Verify USDT was chosen over other available stablecoins
+          verify(
+            () => mockRealWorldProvider.fetchKlines(
+              'BTCUSDT',
+              any(),
+              startUnixTimestampMilliseconds: any(
+                named: 'startUnixTimestampMilliseconds',
+              ),
+              endUnixTimestampMilliseconds: any(
+                named: 'endUnixTimestampMilliseconds',
+              ),
+              limit: 1,
+              baseUrl: any(named: 'baseUrl'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test('ETH should fallback to USDC when USDT not available', () async {
+        final ethAssetId = AssetId(
+          id: 'ethereum',
+          name: 'Ethereum',
+          symbol: AssetSymbol(assetConfigId: 'ETH'),
+          chainId: AssetChainId(chainId: 0),
+          derivationPath: null,
+          subClass: CoinSubClass.utxo,
+        );
+
+        final supportsUsd = await realWorldRepository.supports(
+          ethAssetId,
+          FiatCurrency.usd,
+          PriceRequestType.currentPrice,
+        );
+
+        expect(supportsUsd, isTrue);
+
+        // Mock OHLC for ETHUSDC (fallback since ETHUSDT doesn't exist)
+        final mockOhlc = CoinOhlc(
+          ohlc: [
+            Ohlc.binance(
+              open: Decimal.fromInt(3000),
+              high: Decimal.fromInt(3100),
+              low: Decimal.fromInt(2950),
+              close: Decimal.fromInt(3050),
+              openTime: DateTime.now()
+                  .subtract(const Duration(days: 1))
+                  .millisecondsSinceEpoch,
+              closeTime: DateTime.now().millisecondsSinceEpoch,
+            ),
+          ],
+        );
+
+        when(
+          () => mockRealWorldProvider.fetchKlines(
+            'ETHUSDC',
+            any(),
+            startUnixTimestampMilliseconds: any(
+              named: 'startUnixTimestampMilliseconds',
+            ),
+            endUnixTimestampMilliseconds: any(
+              named: 'endUnixTimestampMilliseconds',
+            ),
+            limit: any(named: 'limit'),
+            baseUrl: any(named: 'baseUrl'),
+          ),
+        ).thenAnswer((_) async => mockOhlc);
+
+        final price = await realWorldRepository.getCoinFiatPrice(
+          ethAssetId,
+          fiatCurrency: FiatCurrency.usd,
+        );
+
+        expect(price, equals(Decimal.fromInt(3050)));
+
+        // Verify USDC was chosen as fallback
+        verify(
+          () => mockRealWorldProvider.fetchKlines(
+            'ETHUSDC',
+            any(),
+            startUnixTimestampMilliseconds: any(
+              named: 'startUnixTimestampMilliseconds',
+            ),
+            endUnixTimestampMilliseconds: any(
+              named: 'endUnixTimestampMilliseconds',
+            ),
+            limit: 1,
+            baseUrl: any(named: 'baseUrl'),
+          ),
+        ).called(1);
+      });
+
+      test(
+        'BNB should fallback to BUSD when USDT and USDC not available',
+        () async {
+          final bnbAssetId = AssetId(
+            id: 'binancecoin',
+            name: 'Binance Coin',
+            symbol: AssetSymbol(assetConfigId: 'BNB'),
+            chainId: AssetChainId(chainId: 0),
+            derivationPath: null,
+            subClass: CoinSubClass.utxo,
+          );
+
+          final supportsUsd = await realWorldRepository.supports(
+            bnbAssetId,
+            FiatCurrency.usd,
+            PriceRequestType.currentPrice,
+          );
+
+          expect(supportsUsd, isTrue);
+
+          // Mock OHLC for BNBBUSD (fallback since BNBUSDT and BNBUSDC don't exist)
+          final mockOhlc = CoinOhlc(
+            ohlc: [
+              Ohlc.binance(
+                open: Decimal.fromInt(300),
+                high: Decimal.fromInt(310),
+                low: Decimal.fromInt(295),
+                close: Decimal.fromInt(305),
+                openTime: DateTime.now()
+                    .subtract(const Duration(days: 1))
+                    .millisecondsSinceEpoch,
+                closeTime: DateTime.now().millisecondsSinceEpoch,
+              ),
+            ],
+          );
+
+          when(
+            () => mockRealWorldProvider.fetchKlines(
+              'BNBBUSD',
+              any(),
+              startUnixTimestampMilliseconds: any(
+                named: 'startUnixTimestampMilliseconds',
+              ),
+              endUnixTimestampMilliseconds: any(
+                named: 'endUnixTimestampMilliseconds',
+              ),
+              limit: any(named: 'limit'),
+              baseUrl: any(named: 'baseUrl'),
+            ),
+          ).thenAnswer((_) async => mockOhlc);
+
+          final price = await realWorldRepository.getCoinFiatPrice(
+            bnbAssetId,
+            fiatCurrency: FiatCurrency.usd,
+          );
+
+          expect(price, equals(Decimal.fromInt(305)));
+
+          // Verify BUSD was chosen as fallback
+          verify(
+            () => mockRealWorldProvider.fetchKlines(
+              'BNBBUSD',
+              any(),
+              startUnixTimestampMilliseconds: any(
+                named: 'startUnixTimestampMilliseconds',
+              ),
+              endUnixTimestampMilliseconds: any(
+                named: 'endUnixTimestampMilliseconds',
+              ),
+              limit: 1,
+              baseUrl: any(named: 'baseUrl'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'NOUSDC should not support USD when no USD stablecoins available',
+        () async {
+          final noUsdAssetId = AssetId(
+            id: 'nousdccoin',
+            name: 'No USDC Coin',
+            symbol: AssetSymbol(assetConfigId: 'NOUSDC'),
+            chainId: AssetChainId(chainId: 0),
+            derivationPath: null,
+            subClass: CoinSubClass.utxo,
+          );
+
+          final supportsUsd = await realWorldRepository.supports(
+            noUsdAssetId,
+            FiatCurrency.usd,
+            PriceRequestType.currentPrice,
+          );
+
+          expect(
+            supportsUsd,
+            isFalse,
+            reason:
+                'NOUSDC should not support USD as it has no USD stablecoins (only EUR, GBP, JPY)',
+          );
+        },
+      );
+
+      test(
+        'should maintain existing behavior for non-USD currencies (EUR exact match required)',
+        () async {
+          final bnbAssetId = AssetId(
+            id: 'binancecoin',
+            name: 'Binance Coin',
+            symbol: AssetSymbol(assetConfigId: 'BNB'),
+            chainId: AssetChainId(chainId: 0),
+            derivationPath: null,
+            subClass: CoinSubClass.utxo,
+          );
+
+          // BNB doesn't have EUR pair in our test data
+          final supportsEur = await realWorldRepository.supports(
+            bnbAssetId,
+            FiatCurrency.eur,
+            PriceRequestType.currentPrice,
+          );
+
+          expect(
+            supportsEur,
+            isFalse,
+            reason:
+                'BNB should not support EUR as exact match is required for non-USD currencies',
+          );
+
+          // But NOUSDC does have EUR pair
+          final noUsdAssetId = AssetId(
+            id: 'nousdccoin',
+            name: 'No USDC Coin',
+            symbol: AssetSymbol(assetConfigId: 'NOUSDC'),
+            chainId: AssetChainId(chainId: 0),
+            derivationPath: null,
+            subClass: CoinSubClass.utxo,
+          );
+
+          final noUsdSupportsEur = await realWorldRepository.supports(
+            noUsdAssetId,
+            FiatCurrency.eur,
+            PriceRequestType.currentPrice,
+          );
+
+          expect(
+            noUsdSupportsEur,
+            isTrue,
+            reason: 'NOUSDC should support EUR as it has direct EUR pair',
+          );
+        },
+      );
+
+      test(
+        'should provide access to USD stablecoin priority configuration',
+        () {
+          final priority = BinanceRepository.usdStablecoinPriority;
+
+          // Verify configuration is accessible
+          expect(priority, isNotEmpty);
+
+          // Verify expected top priorities are present and in correct order
+          expect(priority.first, equals('USDT'));
+          expect(priority[1], equals('USDC'));
+          expect(priority[2], equals('BUSD'));
+
+          // Verify the list is immutable
+          expect(() => priority.add('TEST'), throwsA(isA<UnsupportedError>()));
+
+          // Verify all expected stablecoins are present
+          const expectedStablecoins = [
+            'USDT',
+            'USDC',
+            'BUSD',
+            'FDUSD',
+            'TUSD',
+            'USDP',
+            'DAI',
+            'FRAX',
+            'LUSD',
+            'GUSD',
+            'SUSD',
+            'FEI',
+          ];
+
+          for (final stablecoin in expectedStablecoins) {
+            expect(
+              priority.contains(stablecoin),
+              isTrue,
+              reason: 'Priority list should contain $stablecoin',
+            );
+          }
+        },
+      );
+
+      test(
+        'should provide detailed ArgumentError messages with value and name',
+        () async {
+          final invalidAssetId = AssetId(
+            id: 'invalidcoin',
+            name: 'Invalid Coin',
+            symbol: AssetSymbol(assetConfigId: 'INVALID'),
+            chainId: AssetChainId(chainId: 0),
+            derivationPath: null,
+            subClass: CoinSubClass.utxo,
+          );
+
+          try {
+            await realWorldRepository.getCoinFiatPrice(
+              invalidAssetId,
+              fiatCurrency: FiatCurrency.usd,
+            );
+            fail('Should have thrown ArgumentError');
+          } catch (e) {
+            expect(e, isA<ArgumentError>());
+            final error = e as ArgumentError;
+            expect(error.name, equals('assetId'));
+            expect(error.invalidValue, equals('INVALID'));
+            expect(error.message, contains('Asset not found'));
+          }
+        },
+      );
+    });
   });
 }

--- a/packages/komodo_cex_market_data/test/binance/binance_test_helpers.dart
+++ b/packages/komodo_cex_market_data/test/binance/binance_test_helpers.dart
@@ -42,6 +42,9 @@ BinanceExchangeInfoResponseReduced buildComprehensiveExchangeInfo({
       _createSymbol(symbol: 'BTCGUSD', baseAsset: 'BTC', quoteAsset: 'GUSD'),
       _createSymbol(symbol: 'BTCSUSD', baseAsset: 'BTC', quoteAsset: 'SUSD'),
       _createSymbol(symbol: 'BTCFEI', baseAsset: 'BTC', quoteAsset: 'FEI'),
+      // VIA coin - only supports BNB and ETH, not USDT (to test currency mapping bug)
+      _createSymbol(symbol: 'VIABNB', baseAsset: 'VIA', quoteAsset: 'BNB'),
+      _createSymbol(symbol: 'VIAETH', baseAsset: 'VIA', quoteAsset: 'ETH'),
     ],
   );
 }

--- a/packages/komodo_cex_market_data/test/binance/binance_test_helpers.dart
+++ b/packages/komodo_cex_market_data/test/binance/binance_test_helpers.dart
@@ -45,6 +45,9 @@ BinanceExchangeInfoResponseReduced buildComprehensiveExchangeInfo({
       // VIA coin - only supports BNB and ETH, not USDT (to test currency mapping bug)
       _createSymbol(symbol: 'VIABNB', baseAsset: 'VIA', quoteAsset: 'BNB'),
       _createSymbol(symbol: 'VIAETH', baseAsset: 'VIA', quoteAsset: 'ETH'),
+      // TEST coin - only supports BUSD and USDC, not USDT (to test USD stablecoin fallback)
+      _createSymbol(symbol: 'TESTBUSD', baseAsset: 'TEST', quoteAsset: 'BUSD'),
+      _createSymbol(symbol: 'TESTUSDC', baseAsset: 'TEST', quoteAsset: 'USDC'),
     ],
   );
 }
@@ -56,6 +59,95 @@ BinanceExchangeInfoResponseReduced buildMinimalExchangeInfo({int? serverTime}) {
         serverTime ?? 1640995200000, // Fixed timestamp: 2022-01-01 00:00:00 UTC
     symbols: [
       _createSymbol(symbol: 'BTCEUR', baseAsset: 'BTC', quoteAsset: 'EUR'),
+    ],
+  );
+}
+
+BinanceExchangeInfoResponseReduced buildExchangeInfoWithFallbackStablecoins({
+  int? serverTime,
+}) {
+  return BinanceExchangeInfoResponseReduced(
+    timezone: 'UTC',
+    serverTime:
+        serverTime ?? 1640995200000, // Fixed timestamp: 2022-01-01 00:00:00 UTC
+    symbols: [
+      // BTC has all major USD stablecoins
+      _createSymbol(symbol: 'BTCUSDT', baseAsset: 'BTC', quoteAsset: 'USDT'),
+      _createSymbol(symbol: 'BTCUSDC', baseAsset: 'BTC', quoteAsset: 'USDC'),
+      _createSymbol(symbol: 'BTCBUSD', baseAsset: 'BTC', quoteAsset: 'BUSD'),
+      // FALLBACK coin - only has BUSD (no USDT or USDC)
+      _createSymbol(
+        symbol: 'FALLBACKBUSD',
+        baseAsset: 'FALLBACK',
+        quoteAsset: 'BUSD',
+      ),
+      // ONLYUSDC coin - only has USDC (no USDT or BUSD)
+      _createSymbol(
+        symbol: 'ONLYUSDCUSDC',
+        baseAsset: 'ONLYUSDC',
+        quoteAsset: 'USDC',
+      ),
+      // NOUSD coin - has no USD stablecoins at all
+      _createSymbol(symbol: 'NOUSDEUR', baseAsset: 'NOUSD', quoteAsset: 'EUR'),
+      _createSymbol(symbol: 'NOUSDBNB', baseAsset: 'NOUSD', quoteAsset: 'BNB'),
+    ],
+  );
+}
+
+BinanceExchangeInfoResponseReduced buildRealWorldExampleExchangeInfo({
+  int? serverTime,
+}) {
+  return BinanceExchangeInfoResponseReduced(
+    timezone: 'UTC',
+    serverTime:
+        serverTime ?? 1640995200000, // Fixed timestamp: 2022-01-01 00:00:00 UTC
+    symbols: [
+      // BTC - has all major USD stablecoins
+      _createSymbol(symbol: 'BTCUSDT', baseAsset: 'BTC', quoteAsset: 'USDT'),
+      _createSymbol(symbol: 'BTCUSDC', baseAsset: 'BTC', quoteAsset: 'USDC'),
+      _createSymbol(symbol: 'BTCBUSD', baseAsset: 'BTC', quoteAsset: 'BUSD'),
+      _createSymbol(symbol: 'BTCTUSD', baseAsset: 'BTC', quoteAsset: 'TUSD'),
+      _createSymbol(symbol: 'BTCPAX', baseAsset: 'BTC', quoteAsset: 'PAX'),
+      _createSymbol(symbol: 'BTCFDUSD', baseAsset: 'BTC', quoteAsset: 'FDUSD'),
+      _createSymbol(symbol: 'BTCDAI', baseAsset: 'BTC', quoteAsset: 'DAI'),
+
+      // ETH - has most USD stablecoins but missing USDT
+      _createSymbol(symbol: 'ETHUSDC', baseAsset: 'ETH', quoteAsset: 'USDC'),
+      _createSymbol(symbol: 'ETHBUSD', baseAsset: 'ETH', quoteAsset: 'BUSD'),
+      _createSymbol(symbol: 'ETHTUSD', baseAsset: 'ETH', quoteAsset: 'TUSD'),
+      _createSymbol(symbol: 'ETHPAX', baseAsset: 'ETH', quoteAsset: 'PAX'),
+      _createSymbol(symbol: 'ETHFDUSD', baseAsset: 'ETH', quoteAsset: 'FDUSD'),
+
+      // BNB - only has BUSD and FDUSD (no USDT or USDC)
+      _createSymbol(symbol: 'BNBBUSD', baseAsset: 'BNB', quoteAsset: 'BUSD'),
+      _createSymbol(symbol: 'BNBFDUSD', baseAsset: 'BNB', quoteAsset: 'FDUSD'),
+      _createSymbol(symbol: 'BNBRUB', baseAsset: 'BNB', quoteAsset: 'RUB'),
+      _createSymbol(symbol: 'BNBTRY', baseAsset: 'BNB', quoteAsset: 'TRY'),
+
+      // ADA - only has lower priority stablecoins
+      _createSymbol(symbol: 'ADAPAX', baseAsset: 'ADA', quoteAsset: 'PAX'),
+      _createSymbol(symbol: 'ADATUSD', baseAsset: 'ADA', quoteAsset: 'TUSD'),
+      _createSymbol(symbol: 'ADAEUR', baseAsset: 'ADA', quoteAsset: 'EUR'),
+
+      // RARE coin - only has one obscure USD stablecoin
+      _createSymbol(symbol: 'RAREUSDS', baseAsset: 'RARE', quoteAsset: 'USDS'),
+
+      // NOUSDC coin - has no USD stablecoins at all
+      _createSymbol(
+        symbol: 'NOUSDCEUR',
+        baseAsset: 'NOUSDC',
+        quoteAsset: 'EUR',
+      ),
+      _createSymbol(
+        symbol: 'NOUSDCGBP',
+        baseAsset: 'NOUSDC',
+        quoteAsset: 'GBP',
+      ),
+      _createSymbol(
+        symbol: 'NOUSDCJPY',
+        baseAsset: 'NOUSDC',
+        quoteAsset: 'JPY',
+      ),
     ],
   );
 }


### PR DESCRIPTION
Binance has per-coin quote currency lists that differ greatly, so this PR 

- Uses the asset-specific quote currencies list in the `supports` check, and 
- Adds a mapping from USDT to other USD stable coins like USDC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds automatic USD stablecoin fallback for quote currencies when direct USD pairs aren’t available.
  - Exposes a read-only USD stablecoin priority list for reference.
  - Improves error messages when assets or suitable quote currencies aren’t available.

- Tests
  - Significantly expands coverage for USD fallback behavior, price/24h change retrieval, non-USD currencies, and error handling.
  - Adds comprehensive exchange info fixtures to simulate real-world and edge cases.

- Refactor
  - Cleans up imports in the CoinGecko repository to rely on existing type availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->