### PR TITLE
chore: KW release v0.9.3 fixes

### DIFF
--- a/packages/komodo_defi_framework/app_build/build_config.json
+++ b/packages/komodo_defi_framework/app_build/build_config.json
@@ -1,7 +1,7 @@
 {
     "api": {
-        "api_commit_hash": "a9fbf6096257b802e0aac4d936dcc5d2f0c28461",
-        "branch": "main",
+        "api_commit_hash": "476262f0d3390e24cfe672d5e15a78a46397dbfa",
+        "branch": "hotfix-remove-memorydb-size-metric",
         "fetch_at_build_enabled": true,
         "concurrent_downloads_enabled": true,
         "source_urls": [
@@ -12,49 +12,49 @@
             "web": {
                 "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-wasm|mm2_[a-f0-9]{7,40}-wasm|mm2-[a-f0-9]{7,40}-wasm)\\.zip$",
                 "valid_zip_sha256_checksums": [
-                    "d4476637d566a87974ed54bd708e83f9d05a45a7dfae7ade57c0d00b0f0df631"
+                    "1ce88c3ef6ee4da3839b392e77d9f667a897c4b0b9f4459f878a1561193541a7"
                 ],
                 "path": "web/kdf/bin"
             },
             "ios": {
                 "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-ios-aarch64|mm2_[a-f0-9]{7,40}-ios-aarch64|mm2-[a-f0-9]{7,40}-ios-aarch64-CI)\\.zip$",
                 "valid_zip_sha256_checksums": [
-                    "efd8e8e738541a4838a2b044edc60030db9a4ba14392e30fb1a152472d4f4313"
+                    "68569c2bb3362dc94dd54b0e696559962fab8b29bd1203dd252078aeb1863ca3"
                 ],
                 "path": "ios"
             },
             "macos": {
                 "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-mac-arm64|mm2-[a-f0-9]{7,40}-Darwin-Release)\\.zip$",
                 "valid_zip_sha256_checksums": [
-                    "bc411c8d95dbe565b0e56871babaea7412ccbd1ad7f525f3cf56a384a4a77ee7"
+                    "9613497ec79dab437251fb0c1ca6301c1b389325a01a8a979fde690d975c9902"
                 ],
                 "path": "macos/bin"
             },
             "windows": {
                 "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-win-x86-64|mm2_[a-f0-9]{7,40}-win-x86-64|mm2-[a-f0-9]{7,40}-Win64)\\.zip$",
                 "valid_zip_sha256_checksums": [
-                    "d9849d01962b4e05899cde7ec17f6b9e8ba9411f484369724c7a73a4b6a3fb80"
+                    "d25b417ef17685e439f6be9f1100dfa46b5e9b3ef646037066a5b5db0852f107"
                 ],
                 "path": "windows/bin"
             },
             "android-armv7": {
                 "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-android-armv7|mm2_[a-f0-9]{7,40}-android-armv7|mm2-[a-f0-9]{7,40}-android-armv7-CI)\\.zip$",
                 "valid_zip_sha256_checksums": [
-                    "10ae609f3c7e4ed47e5a1134dd74da84375f9a1c6538c985afb1c148d58f8756"
+                    "92e0d9515d3fb662bf90dc37802f901944d99b3c4b8e41566e6defacd59e213c"
                 ],
                 "path": "android/app/src/main/cpp/libs/armeabi-v7a"
             },
             "android-aarch64": {
                 "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-android-aarch64|mm2_[a-f0-9]{7,40}-android-aarch64|mm2-[a-f0-9]{7,40}-android-aarch64-CI)\\.zip$",
                 "valid_zip_sha256_checksums": [
-                    "ab4b5311e0d1b6b2f57ed1783d5b7a51c4b7558cbf0bad593d9235f6a32db906"
+                    "4d6dc94ba31087180df09136c51bc61c75fd217e77889eb45ef40e0c6a34537f"
                 ],
                 "path": "android/app/src/main/cpp/libs/arm64-v8a"
             },
             "linux": {
                 "matching_pattern": "^(?:kdf_[a-f0-9]{7,40}-linux-x86-64|mm2_[a-f0-9]{7,40}-linux-x86-64|mm2-[a-f0-9]{7,40}-Linux-Release)\\.zip$",
                 "valid_zip_sha256_checksums": [
-                    "913a165e434ed9696c0e8c9a1875bfd6448e291f85d2e7e8dae78618ef3534e3"
+                    "7ab3d56bd0ad56e383903e3f0a444369f67b7945661f6fd0076a96b8d795cfbb"
                 ],
                 "path": "linux/bin"
             }
@@ -63,7 +63,7 @@
     "coins": {
         "fetch_at_build_enabled": true,
         "update_commit_on_build": true,
-        "bundled_coins_repo_commit": "163c0946bbeb9c4a0e4f9d9553569167e7c147e0",
+        "bundled_coins_repo_commit": "f235190081e821996333c95e34b2629df331b333",
         "coins_repo_api_url": "https://api.github.com/repos/KomodoPlatform/coins",
         "coins_repo_content_url": "https://raw.githubusercontent.com/KomodoPlatform/coins",
         "coins_repo_branch": "master",


### PR DESCRIPTION
This PR updates the API configuration to use the `hotfix-remove-memorydb-size-metric` branch from the hosted endpoint for the Komodo Wallet v0.9.3 release and will include any further KDF staging fixes needed.

## Changes
- Updated branch from `main` to `hotfix-remove-memorydb-size-metric`
- Updated commit hash to `476262f0d3390e24cfe672d5e15a78a46397dbfa`
- Updated SHA-256 checksums for all platform binaries:
  - Web (WASM)
  - iOS (aarch64)
  - macOS (ARM64)
  - Windows (x86-64)
  - Android (ARMv7 & AArch64)
  - Linux (x86-64)

All binaries were fetched from the mirror site at https://sdk.devbuilds.komodo.earth/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update API to `hotfix-remove-memorydb-size-metric` commit and refresh platform binary checksums; update bundled coins repo commit.
> 
> - **Build Config (`packages/komodo_defi_framework/app_build/build_config.json`)**:
>   - **API**:
>     - Update `branch` to `hotfix-remove-memorydb-size-metric` and `api_commit_hash` to `476262f0d3390e24cfe672d5e15a78a46397dbfa`.
>     - Refresh `valid_zip_sha256_checksums` for platforms: `web`, `ios`, `macos`, `windows`, `android-armv7`, `android-aarch64`, `linux`.
>   - **Coins**:
>     - Update `bundled_coins_repo_commit` to `f235190081e821996333c95e34b2629df331b333`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72c9de3b370f1b4169ebbb3150e8adedf4ed3b23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->